### PR TITLE
Add FBC OCP version support workflow

### DIFF
--- a/.agents/workflows/add-fbc-ocp-version.md
+++ b/.agents/workflows/add-fbc-ocp-version.md
@@ -1,0 +1,65 @@
+# Add FBC Support for New OCP Version
+
+**When:** Red Hat releases new OCP version and ACM announces support
+
+**Note:** This is an async/maintenance task, not tied to Submariner version releases (0.21, 0.22, etc.).
+It's triggered by Red Hat's OCP release schedule and ACM's announced OCP support matrix.
+
+## Process
+
+### 1. Update FBC Catalog Source
+
+Add catalog directory and Tekton pipelines for new OCP version.
+
+**Repo:** <https://github.com/stolostron/submariner-operator-fbc>
+**Local:** `~/konflux/submariner-operator-fbc`
+
+**Workflow:** `CLAUDE.md` → `.agents/workflows/add-ocp-version.md`
+
+### 2. Update Konflux Tenant Config
+
+Add overlay, tenant config, and RPA entries for new OCP version.
+
+**Repo:** <https://gitlab.cee.redhat.com/releng/konflux-release-data>
+**Local:** `~/konflux/konflux-release-data`
+
+**Workflow:** `tenants-config/cluster/kflux-prd-rh02/tenants/submariner-tenant/CLAUDE.md` → "Add FBC Support for New OCP Version"
+
+### 3. Update Release Workflows (this repo)
+
+Update OCP version ranges in bash loops. Replace `4-XX` with new version in:
+
+- `create-fbc-stage-release.md` - Snapshot verification loops
+- `create-fbc-prod-release.md` - Copy instructions
+- `check-fbc-releases.md` - Status check loops
+- `apply-fbc-releases.md` - Apply instructions
+- `share-with-qe.md` - URL extraction loops
+- `update-fbc-stage.md` - OCP version ranges in Done When
+
+```bash
+# Example: Adding 4-21 to existing 4-16 through 4-20 range
+# Change: for VERSION in 16 17 18 19 20
+# To:     for VERSION in 16 17 18 19 20 21
+```
+
+## Done When
+
+- FBC repo has `catalog-4-XX/` directory on main branch
+- Konflux snapshots building for new OCP version:
+
+  ```bash
+  oc get snapshots -n submariner-tenant --sort-by=.metadata.creationTimestamp | grep "submariner-fbc-4-XX" | tail -1
+  # Should show snapshot name
+  ```
+
+- ArgoCD has deployed resources (requires `oc login --web https://api.kflux-prd-rh02.0fk9.p1.openshiftapps.com:6443/`):
+
+  ```bash
+  oc get application -n submariner-tenant | grep fbc-4-XX
+  # Should show: submariner-fbc-4-XX
+
+  oc get releaseplans -n submariner-tenant | grep fbc.*4-XX
+  # Should show: submariner-fbc-release-plan-{stage,prod}-4-XX
+  ```
+
+- Release workflows in this repo updated with new OCP version in loops

--- a/.agents/workflows/add-release-notes.md
+++ b/.agents/workflows/add-release-notes.md
@@ -22,7 +22,11 @@ Add complete release notes to stage YAML. QE verifies both code and release note
 3. Add token to shell config (e.g., `~/.zshrc`): `export JIRA_API_TOKEN="your-token"`
 4. Reload shell: `source ~/.zshrc`
 5. Initialize:
-   `jira init --installation local --auth-type bearer --server https://issues.redhat.com --login rhn-support-tiwillia --project ACM --board none`
+
+   ```bash
+   jira init --installation local --auth-type bearer --server https://issues.redhat.com \
+     --login rhn-support-tiwillia --project ACM --board none
+   ```
 
 **Claude: Test if setup works with:**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,3 +103,13 @@
 ## 20. Update FBC Templates with Prod URLs (Optional)
 
 @.agents/workflows/update-fbc-templates-prod.md
+
+---
+
+## Async / Maintenance Tasks
+
+Tasks not tied to normal release workflow timing.
+
+### Add FBC Support for New OCP Version
+
+@.agents/workflows/add-fbc-ocp-version.md


### PR DESCRIPTION
Adds async/maintenance task documentation for adding new OCP version support to FBC. Links to workflows in submariner-operator-fbc and konflux-release-data repos.

Also fixes markdown lint in add-release-notes.md.