### PR TITLE
Add OCP 4.21 support to FBC workflow docs

### DIFF
--- a/.agents/workflows/add-release-notes.md
+++ b/.agents/workflows/add-release-notes.md
@@ -24,8 +24,9 @@ Add complete release notes to stage YAML. QE verifies both code and release note
 5. Initialize:
 
    ```bash
-   jira init --installation local --auth-type bearer --server https://issues.redhat.com \
-     --login rhn-support-tiwillia --project ACM --board none
+   jira init --installation local --auth-type bearer \
+     --server https://issues.redhat.com --login rhn-support-tiwillia \
+     --project ACM --board none
    ```
 
 **Claude: Test if setup works with:**

--- a/.agents/workflows/apply-fbc-releases.md
+++ b/.agents/workflows/apply-fbc-releases.md
@@ -4,7 +4,7 @@
 
 ## Process
 
-Apply all FBC YAMLs to cluster (one per OCP version: 4-16 through 4-20).
+Apply all FBC YAMLs to cluster (one per OCP version: 4-16 through 4-21).
 
 **Repo:** `~/konflux/submariner-release-management`
 
@@ -34,6 +34,6 @@ All FBC releases running and completed successfully.
 # Verify all releases on cluster
 oc get releases -n submariner-tenant | grep -E "fbc.*(stage|prod)" | sort
 
-# Verify files in repo (expect: 5 at Step 13 stage, 10 at Step 18 after prod added)
+# Verify files in repo (expect: 6 at Step 13 stage, 12 at Step 18 after prod added)
 git ls-tree -r --name-only origin/main releases/fbc/ | grep -E "(stage|prod)" | wc -l
 ```

--- a/.agents/workflows/check-fbc-releases.md
+++ b/.agents/workflows/check-fbc-releases.md
@@ -4,13 +4,13 @@
 
 ## Process
 
-Monitor FBC release pipeline executions for all OCP versions (4-16 through 4-20) and verify successful completion.
+Monitor FBC release pipeline executions for all OCP versions (4-16 through 4-21) and verify successful completion.
 
 ## Check Build Status
 
 ```bash
 # Check all FBC stage releases (replace 'stage' with 'prod' for Step 18)
-for VERSION in 16 17 18 19 20; do
+for VERSION in 16 17 18 19 20 21; do
   RELEASE=$(oc get release -n submariner-tenant --no-headers | grep "submariner-fbc-4-$VERSION-stage" | tail -1 | awk '{print $1}')
   [ -z "$RELEASE" ] && { echo "4-$VERSION: Not applied"; continue; }
 
@@ -130,7 +130,7 @@ After apply, agent returns to **Check Build Status** section to verify retry suc
 
 ## Done When
 
-- All 5 FBC release pipelines completed successfully (4-16 through 4-20)
+- All 6 FBC release pipelines completed successfully (4-16 through 4-21)
 - Index images published to target registries
 - Catalogs updated in indices
 - Ready for next step

--- a/.agents/workflows/create-fbc-prod-release.md
+++ b/.agents/workflows/create-fbc-prod-release.md
@@ -14,7 +14,7 @@ stage and prod (bundle is mirrored). Catalog update to registry.redhat.io URL ha
 
 ## Creating Prod YAMLs
 
-Agent creates prod YAML for each OCP version (4-16 through 4-20):
+Agent creates prod YAML for each OCP version (4-16 through 4-21):
 
 ```bash
 # Copy from stage
@@ -41,6 +41,6 @@ User reviews commit, then pushes.
 FBC prod YAMLs created, committed, and pushed. Ready for Step 18 to apply to cluster.
 
 ```bash
-# Verify files pushed to remote (expect: 4-16 through 4-20)
+# Verify files pushed to remote (expect: 4-16 through 4-21)
 git ls-tree -r --name-only origin/main releases/fbc/*/prod/*.yaml
 ```

--- a/.agents/workflows/share-with-qe.md
+++ b/.agents/workflows/share-with-qe.md
@@ -14,7 +14,7 @@ Agent extracts catalog URLs for all OCP versions from stage snapshots:
 
 ```bash
 echo "=== FBC Stage Catalog URLs for QE ==="
-for VERSION in 16 17 18 19 20; do
+for VERSION in 16 17 18 19 20 21; do
   STAGE_YAML=$(ls releases/fbc/4-$VERSION/stage/*.yaml | tail -1)
   SNAPSHOT=$(awk '/^  snapshot:/ {print $2}' "$STAGE_YAML")
   CATALOG=$(oc get snapshot "$SNAPSHOT" -n submariner-tenant \
@@ -23,7 +23,7 @@ for VERSION in 16 17 18 19 20; do
 done
 ```
 
-Example output (5 catalog URLs):
+Example output (6 catalog URLs):
 
 ```text
 OCP 4.16: quay.io/redhat-user-workloads/submariner-tenant/submariner-fbc-4-16@sha256:...
@@ -31,6 +31,7 @@ OCP 4.17: quay.io/redhat-user-workloads/submariner-tenant/submariner-fbc-4-17@sh
 OCP 4.18: quay.io/redhat-user-workloads/submariner-tenant/submariner-fbc-4-18@sha256:...
 OCP 4.19: quay.io/redhat-user-workloads/submariner-tenant/submariner-fbc-4-19@sha256:...
 OCP 4.20: quay.io/redhat-user-workloads/submariner-tenant/submariner-fbc-4-20@sha256:...
+OCP 4.21: quay.io/redhat-user-workloads/submariner-tenant/submariner-fbc-4-21@sha256:...
 ```
 
 ### Verify Stage Catalog Content
@@ -38,8 +39,8 @@ OCP 4.20: quay.io/redhat-user-workloads/submariner-tenant/submariner-fbc-4-20@sh
 Verify one catalog contains the expected bundle version:
 
 ```bash
-# Pick one catalog to verify (e.g., 4-20)
-CATALOG="quay.io/redhat-user-workloads/submariner-tenant/submariner-fbc-4-20@sha256:..."
+# Pick one catalog to verify (e.g., 4-21)
+CATALOG="quay.io/redhat-user-workloads/submariner-tenant/submariner-fbc-4-21@sha256:..."
 
 # Extract and list bundles
 TMPDIR=$(mktemp -d)
@@ -62,7 +63,7 @@ rm -rf $TMPDIR
 Create ticket with:
 
 - **Summary:** "Submariner 0.X.Y FBC Stage Ready for Testing"
-- **Description:** Include all 5 catalog URLs
+- **Description:** Include all 6 catalog URLs
 - **Installation:** Point to FBC installation docs (CatalogSource creation)
 
 **Key concept:** Catalog contains operator bundle with registry.redhat.io URLs. ImageDigestMirrors in
@@ -78,11 +79,11 @@ cluster redirect to quay.io for actual image pulls.
 
 ## Share Prod FBC with QE
 
-**When:** When all 5 FBC prod releases show Succeeded status
+**When:** When all 6 FBC prod releases show Succeeded status
 
 ### Check Release Status
 
-Verify all 5 FBC prod releases completed:
+Verify all 6 FBC prod releases completed:
 
 ```bash
 oc get releases -n submariner-tenant --no-headers | \
@@ -99,7 +100,7 @@ Extract index URLs and format message for QE:
 ```bash
 echo "Submariner 0.X.Y Prod FBC Released"
 echo ""
-for VERSION in 16 17 18 19 20; do
+for VERSION in 16 17 18 19 20 21; do
   RELEASE=$(oc get releases -n submariner-tenant --no-headers | \
     grep "submariner-fbc-4-$VERSION-prod.*Succeeded" | tail -1 | awk '{print $1}')
 
@@ -117,12 +118,12 @@ Replace `0.X.Y` with actual version. Copy the output and share with QE.
 
 ### Verify Index Images (Optional)
 
-**TODO:** Implement verification that all 5 index images contain the expected Submariner 0.X.Y bundle SHA.
+**TODO:** Implement verification that all 6 index images contain the expected Submariner 0.X.Y bundle SHA.
 
 **What to verify:**
 
 - Extract bundle SHA from prod release YAML files
-- Check each of 5 index images contains that bundle SHA
+- Check each of 6 index images contains that bundle SHA
 - Verify bundle version matches expected release (0.X.Y)
 
 **Why optional:** QE testing will catch issues if bundle missing/wrong. This verification adds confidence but isn't blocking.
@@ -135,6 +136,6 @@ Replace `0.X.Y` with actual version. Copy the output and share with QE.
 
 ### Prod Done When
 
-- All 5 FBC prod releases succeeded
+- All 6 FBC prod releases succeeded
 - QE message shared with index URLs
 - **Submariner 0.X.Y production release COMPLETE**

--- a/.agents/workflows/update-fbc-stage.md
+++ b/.agents/workflows/update-fbc-stage.md
@@ -12,7 +12,7 @@ Update catalog in FBC repo with bundle from completed stage release.
 
 ## Done When
 
-For each OCP version (4-16 through 4-20):
+For each OCP version (4-16 through 4-21):
 
 ```bash
 # 1. Check latest snapshot created after catalog update

--- a/.agents/workflows/update-fbc-templates-prod.md
+++ b/.agents/workflows/update-fbc-templates-prod.md
@@ -20,6 +20,6 @@ Update FBC catalog templates to use prod registry.redhat.io bundle URLs instead 
 
 ## Done When
 
-- Template file updated with registry.redhat.io URLs (renders to 5 OCP catalogs)
+- Template file updated with registry.redhat.io URLs (renders to 6 OCP catalogs)
 - `make build-catalog` verified working
 - Changes committed and pushed to FBC repo


### PR DESCRIPTION
Update version loops and prose ranges in release workflow documentation:
- Version loops: 16 17 18 19 20 → 16 17 18 19 20 21
- Prose ranges: 4-16 through 4-20 → 4-16 through 4-21
- FBC counts: 5 → 6 (catalogs, snapshots, releases)
- Representative catalog: 4-20 → 4-21
- File count expectations: 5/10 → 6/12

Also fixes pre-existing markdown lint error in add-release-notes.md.