### PR TITLE
Add git commit message linting

### DIFF
--- a/.github/workflows/gitlint.yml
+++ b/.github/workflows/gitlint.yml
@@ -1,0 +1,23 @@
+---
+name: Commit Message Lint
+
+'on':
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions: {}
+
+jobs:
+  gitlint:
+    name: Commit Message(s)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install gitlint
+        run: pip install gitlint
+      - name: Run gitlint
+        run: make gitlint

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,21 @@
+[general]
+# body-is-missing: Allow commit messages with only a title
+# body-min-length: Allow short body lines, like "Relates-to: #issue"
+ignore=body-is-missing,body-min-length
+# Our ignore-by-body regex is correct for re.search(). Required for suppressing a warning. See:
+# https://jorisroovers.com/gitlint/latest/configuration/general_options/#regex-style-search
+regex-style-search=true
+
+[ignore-by-body]
+# Dependabot doesn't follow our conventions, unfortunately
+regex=^Signed-off-by: dependabot\[bot\](.*)
+ignore=all
+
+[ignore-by-author-name]
+# Konflux doesn't follow our conventions, unfortunately
+regex=red-hat-konflux
+ignore=all
+
+[ignore-body-lines]
+# Allow long URLs in commit messages
+regex=^https?://[^ ]*$

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test test-remote validate-yaml validate-fields validate-data validate-references validate-bundle-images validate-markdown apply watch
+.PHONY: help test test-remote validate-yaml validate-fields validate-data validate-references validate-bundle-images validate-markdown gitlint apply watch
 
 .DEFAULT_GOAL := help
 
@@ -12,8 +12,9 @@ help:
 	@echo "  make validate-fields   - Release CRD fields only"
 	@echo "  make validate-data     - Data formats only"
 	@echo "  make validate-markdown - Markdown linting (docs)"
+	@echo "  make gitlint           - Commit message linting"
 
-test: validate-yaml validate-fields validate-data validate-markdown
+test: validate-yaml validate-fields validate-data validate-markdown gitlint
 
 test-remote: test validate-references validate-bundle-images
 
@@ -34,6 +35,9 @@ validate-data:
 
 validate-markdown:
 	npx markdownlint-cli2 ".agents/workflows/*.md" "*.md"
+
+gitlint:
+	gitlint --commits origin/main..HEAD
 
 apply: test-remote
 	@test -n "$(FILE)" || (echo "ERROR: FILE parameter required. Usage: make apply FILE=releases/0.20/stage/..." && exit 1)


### PR DESCRIPTION
Adds gitlint matching Submariner's shipyard config to enforce commit message conventions. Integrated with make test and CI.