### PR TITLE
Add explicit minimal permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -7,6 +7,8 @@ name: Markdown Lint
       - main
   pull_request:
 
+permissions: {}
+
 jobs:
   markdownlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -7,8 +7,7 @@ name: Shellcheck
       - main
   pull_request:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   shellcheck:

--- a/.github/workflows/validate-releases.yml
+++ b/.github/workflows/validate-releases.yml
@@ -7,6 +7,8 @@ name: Validate Releases
       - main
   pull_request:
 
+permissions: {}
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -7,6 +7,8 @@ name: YAML Lint
       - main
   pull_request:
 
+permissions: {}
+
 jobs:
   yamllint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
All 5 workflows now explicitly declare `permissions: {}` (no permissions):
- gitlint.yml: Set to `permissions: {}`
- markdownlint.yml: Set to `permissions: {}`
- validate-releases.yml: Set to `permissions: {}`
- yamllint.yml: Set to `permissions: {}`
- shellcheck.yml: Set to `permissions: {}`

Testing if actions/checkout@v4 works without explicit permissions in both pull_request and push contexts. If any workflow fails in CI, we'll know which ones actually require `contents: read`.

Follows principle of least privilege - using absolute minimum permissions.