### PR TITLE
Support single-file validation via FILE parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,19 +24,19 @@ test: validate-yaml validate-fields validate-data validate-markdown gitlint shel
 test-remote: test validate-references validate-bundle-images
 
 validate-references:
-	./scripts/validate-release-references.sh
+	./scripts/validate-release-references.sh $(FILE)
 
 validate-bundle-images:
-	./scripts/validate-bundle-images.sh
+	./scripts/validate-bundle-images.sh $(FILE)
 
 validate-yaml:
 	yamllint .
 
 validate-fields:
-	./scripts/validate-release-fields.sh
+	./scripts/validate-release-fields.sh $(FILE)
 
 validate-data:
-	./scripts/validate-release-data.sh
+	./scripts/validate-release-data.sh $(FILE)
 
 validate-markdown:
 	npx markdownlint-cli2 "**/*.md"

--- a/scripts/validate-bundle-images.sh
+++ b/scripts/validate-bundle-images.sh
@@ -179,11 +179,23 @@ validate_file() {
   rm -rf "$tmpdir"
 }
 
-# Main
-find releases -name '*.yaml' -type f -print0 | \
-  while IFS= read -r -d '' file; do
-    validate_file "$file"
-  done
-
-echo ""
-echo "All bundle image validations passed"
+# Main - support both single-file and all-files modes
+if [[ $# -gt 0 && -n "$1" ]]; then
+  # Single file mode - validate the provided file
+  file="$1"
+  if [[ ! -f "$file" ]]; then
+    echo "ERROR: File '$file' not found"
+    exit 1
+  fi
+  validate_file "$file"
+  echo ""
+  echo "File validation passed"
+else
+  # All files mode - find and validate all release YAMLs
+  find releases -name '*.yaml' -type f -print0 | \
+    while IFS= read -r -d '' file; do
+      validate_file "$file"
+    done
+  echo ""
+  echo "All bundle image validations passed"
+fi

--- a/scripts/validate-release-data.sh
+++ b/scripts/validate-release-data.sh
@@ -108,11 +108,23 @@ validate_file() {
   echo "✓ $file"
 }
 
-# Main
-find releases -name '*.yaml' -type f -print0 | \
-  while IFS= read -r -d '' file; do
-    validate_file "$file"
-  done
-
-echo ""
-echo "All data formats validated successfully"
+# Main - support both single-file and all-files modes
+if [[ $# -gt 0 && -n "$1" ]]; then
+  # Single file mode - validate the provided file
+  file="$1"
+  if [[ ! -f "$file" ]]; then
+    echo "ERROR: File '$file' not found"
+    exit 1
+  fi
+  validate_file "$file"
+  echo ""
+  echo "File validation passed"
+else
+  # All files mode - find and validate all release YAMLs
+  find releases -name '*.yaml' -type f -print0 | \
+    while IFS= read -r -d '' file; do
+      validate_file "$file"
+    done
+  echo ""
+  echo "All data formats validated successfully"
+fi

--- a/scripts/validate-release-fields.sh
+++ b/scripts/validate-release-fields.sh
@@ -157,11 +157,23 @@ validate_file() {
   echo "✓ $file"
 }
 
-# Main
-find releases -name '*.yaml' -type f -print0 | \
-  while IFS= read -r -d '' file; do
-    validate_file "$file"
-  done
-
-echo ""
-echo "All release files validated successfully"
+# Main - support both single-file and all-files modes
+if [[ $# -gt 0 && -n "$1" ]]; then
+  # Single file mode - validate the provided file
+  file="$1"
+  if [[ ! -f "$file" ]]; then
+    echo "ERROR: File '$file' not found"
+    exit 1
+  fi
+  validate_file "$file"
+  echo ""
+  echo "File validation passed"
+else
+  # All files mode - find and validate all release YAMLs
+  find releases -name '*.yaml' -type f -print0 | \
+    while IFS= read -r -d '' file; do
+      validate_file "$file"
+    done
+  echo ""
+  echo "All release files validated successfully"
+fi

--- a/scripts/validate-release-references.sh
+++ b/scripts/validate-release-references.sh
@@ -97,11 +97,23 @@ validate_file() {
   echo "✓ $file"
 }
 
-# Main
-find releases -name '*.yaml' -type f -print0 | \
-  while IFS= read -r -d '' file; do
-    validate_file "$file"
-  done
-
-echo ""
-echo "All release references validated successfully"
+# Main - support both single-file and all-files modes
+if [[ $# -gt 0 && -n "$1" ]]; then
+  # Single file mode - validate the provided file
+  file="$1"
+  if [[ ! -f "$file" ]]; then
+    echo "ERROR: File '$file' not found"
+    exit 1
+  fi
+  validate_file "$file"
+  echo ""
+  echo "File validation passed"
+else
+  # All files mode - find and validate all release YAMLs
+  find releases -name '*.yaml' -type f -print0 | \
+    while IFS= read -r -d '' file; do
+      validate_file "$file"
+    done
+  echo ""
+  echo "All release references validated successfully"
+fi


### PR DESCRIPTION
Validates one release YAML instead of all 34 when FILE is specified.

Usage:
  make test-remote FILE=releases/0.22/stage/foo.yaml  # ~10s
  make test-remote                                     # ~30s (all files)

Changes:
- Makefile: Pass $(FILE) to validate-{fields,data,references,bundle-images}
- scripts/validate-*.sh: Support optional file argument