### PR TITLE
Add /create-fbc-release skill and make target

### DIFF
--- a/.claude/SKILLS.md
+++ b/.claude/SKILLS.md
@@ -102,6 +102,51 @@ Handles 8 components across 5 repos. Runs 12 automated setup steps and creates p
 
 **After running:** Review commits, validate YAML, push to remote, wait for build (~15-30 min)
 
+## /create-fbc-release
+
+Create FBC releases for all OCP versions (stage or prod) with comprehensive verification
+
+Automates Step 12 (FBC stage releases) and Step 17 (FBC prod releases) of the Submariner release workflow.
+
+```bash
+/create-fbc-release 0.22.1 --stage   # Create stage releases
+/create-fbc-release 0.22.1 --prod    # Create prod releases
+/create-fbc-release 0.22 --stage     # Auto-detects latest patch
+/create-fbc-release 0.22             # Defaults to stage
+```
+
+**Alternative (make target):**
+
+```bash
+make create-fbc-releases VERSION=0.22.1              # Stage (default)
+make create-fbc-releases VERSION=0.22.1 TYPE=prod    # Production
+```
+
+**Prerequisites:**
+
+- `oc login` (required for snapshot queries)
+- Step 10 complete (component stage release)
+- Step 11 complete (FBC catalog updated)
+- FBC snapshots rebuilt (~15-30 min after Step 11)
+
+**What it does:**
+
+1. Verifies GitHub catalog consistency (all 6 OCP versions have same bundle SHA)
+2. Verifies FBC snapshots (push events, tests passed, bundle SHAs match)
+3. Verifies component SHAs across 10 sources (operator repo → registry → FBC GitHub → 6 snapshots)
+4. Generates 6 Release YAMLs (one per OCP version: 4-16 through 4-21)
+5. Validates YAMLs with `make test-remote`
+6. Automatically commits with descriptive message
+
+**After running:**
+
+1. Review commit: `git show`
+2. Push: `git push origin $(git rev-parse --abbrev-ref HEAD)`
+3. Apply releases: `make apply FILE=<yaml>` for each version
+4. Monitor: `make watch NAME=<release-name>`
+
+**To undo:** `git reset HEAD~1`
+
 ## Installation
 
 ### .claude/settings.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,9 @@
 
 ## 12. Create FBC Stage Releases
 
-@.agents/workflows/create-fbc-stage-release.md
+@/create-fbc-release
+
+**Alternative:** @.agents/workflows/create-fbc-stage-release.md (manual workflow)
 
 ## 13. Apply FBC Stage Releases
 
@@ -90,7 +92,9 @@
 
 ## 17. Create FBC Prod Releases
 
-@.agents/workflows/create-fbc-prod-release.md
+@/create-fbc-release
+
+**Alternative:** @.agents/workflows/create-fbc-prod-release.md (manual workflow)
 
 ## 18. Apply FBC Prod Releases
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test test-remote validate-yaml validate-fields validate-data validate-references validate-bundle-images validate-markdown gitlint shellcheck apply watch
+.PHONY: help test test-remote validate-yaml validate-fields validate-data validate-references validate-bundle-images validate-markdown gitlint shellcheck apply watch create-fbc-releases
 
 .DEFAULT_GOAL := help
 
@@ -8,16 +8,31 @@ export SHELLCHECK_ARGS
 
 help:
 	@echo "Available targets:"
+	@echo ""
+	@echo "Release Creation:"
+	@echo "  make create-fbc-releases VERSION=... [TYPE=stage|prod]"
+	@echo "                         - Create FBC releases for all 6 OCP versions (requires oc login)"
+	@echo "                           Default TYPE is stage if not specified"
+	@echo "                           Example: make create-fbc-releases VERSION=0.22.1"
+	@echo "                           Example: make create-fbc-releases VERSION=0.22.1 TYPE=prod"
+	@echo ""
+	@echo "Validation:"
 	@echo "  make test              - Run local validations (no cluster access needed)"
 	@echo "  make test-remote       - Run all validations including cluster checks and bundle images (requires oc login)"
-	@echo "  make apply FILE=...    - Validate and apply release YAML to cluster (requires oc login)"
-	@echo "  make watch NAME=...    - Watch release status (requires oc login)"
 	@echo "  make validate-yaml     - YAML syntax only"
 	@echo "  make validate-fields   - Release CRD fields only"
 	@echo "  make validate-data     - Data formats only"
 	@echo "  make validate-markdown - Markdown linting (docs)"
 	@echo "  make gitlint           - Commit message linting"
 	@echo "  make shellcheck        - Shell script linting"
+	@echo ""
+	@echo "Release Operations:"
+	@echo "  make apply FILE=...    - Validate and apply release YAML to cluster (requires oc login)"
+	@echo "  make watch NAME=...    - Watch release status (requires oc login)"
+
+create-fbc-releases:
+	@test -n "$(VERSION)" || (echo "ERROR: VERSION parameter required. Usage: make create-fbc-releases VERSION=0.22.1 [TYPE=stage|prod]" && exit 1)
+	./scripts/create-fbc-releases.sh $(VERSION) $(if $(TYPE),--$(TYPE),--stage)
 
 test: validate-yaml validate-fields validate-data validate-markdown gitlint shellcheck
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ oc login --web https://api.kflux-prd-rh02.0fk9.p1.openshiftapps.com:6443/
 # Show available commands
 make
 
+# Create FBC releases (requires cluster login)
+make create-fbc-releases VERSION=0.22.1              # Stage (default)
+make create-fbc-releases VERSION=0.22.1 TYPE=prod    # Production
+
 # Validate locally (no cluster access needed)
 make test
 
@@ -39,5 +43,6 @@ make watch NAME=submariner-0-20-2-stage-20250930-01
 | `/add-team-member`         | Add user to Submariner Konflux RBAC            |
 | `/konflux-ci-fix`          | Fix Konflux CI Enterprise Contract issues      |
 | `/konflux-component-setup` | Automate Konflux component setup on new branch |
+| `/create-fbc-release`      | Create FBC releases for all OCP versions       |
 
 See [.claude/SKILLS.md](.claude/SKILLS.md).

--- a/scripts/create-fbc-releases.sh
+++ b/scripts/create-fbc-releases.sh
@@ -1,0 +1,389 @@
+#!/bin/bash
+# Create FBC releases for all OCP versions (stage or prod)
+#
+# Usage: create-fbc-releases.sh <version> [--stage|--prod]
+#
+# Arguments:
+#   version: Submariner version (e.g., 0.22.1 or 0.22)
+#   --stage/--prod: Release type (default: stage)
+#
+# Exit codes:
+#   0: Success (releases created and committed)
+#   1: Failure (prerequisites, validation, or commit failed)
+
+set -euo pipefail
+
+# Global variables (set by parse_arguments)
+VERSION=""
+RELEASE_TYPE="stage"
+GIT_ROOT=""
+SCRIPTS_DIR=""
+RELEASES_DIR=""
+
+# Global variables (set by verify_release)
+declare -A SNAPSHOTS
+
+# Global variables (set by generate_yamls)
+declare -a CREATED_FILES
+
+# ============================================================================
+# Prerequisites Check
+# ============================================================================
+
+check_prerequisites() {
+  local MISSING_TOOLS=()
+
+  command -v oc &>/dev/null || MISSING_TOOLS+=("oc")
+  command -v jq &>/dev/null || MISSING_TOOLS+=("jq")
+  command -v curl &>/dev/null || MISSING_TOOLS+=("curl")
+  command -v git &>/dev/null || MISSING_TOOLS+=("git")
+
+  if [ "${#MISSING_TOOLS[@]}" -gt 0 ]; then
+    echo "❌ ERROR: Missing required tools: ${MISSING_TOOLS[*]}"
+    echo ""
+    echo "Installation instructions:"
+    for tool in "${MISSING_TOOLS[@]}"; do
+      case "$tool" in
+        oc) echo "  oc: https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html" ;;
+        jq) echo "  jq: https://jqlang.github.io/jq/download/" ;;
+        curl) echo "  curl: included in most systems" ;;
+        git) echo "  git: https://git-scm.com/downloads" ;;
+      esac
+    done
+    exit 1
+  fi
+
+  # Check bash version
+  local BASH_MAJOR
+  BASH_MAJOR=$(bash -c 'echo ${BASH_VERSINFO[0]}' 2>/dev/null)
+  if [ -z "$BASH_MAJOR" ]; then
+    BASH_MAJOR=$(bash --version 2>/dev/null | head -1 | sed -nE 's/.*version ([0-9]+).*/\1/p')
+  fi
+
+  if [ -z "$BASH_MAJOR" ] || [ "$BASH_MAJOR" -lt 4 ]; then
+    local BASH_VER
+    BASH_VER=$(bash --version 2>/dev/null | head -1 || echo "unknown")
+    echo "❌ ERROR: bash 4.0+ required (current: $BASH_VER)"
+    echo "This script uses associative arrays (declare -A) which require bash 4.0+."
+    echo ""
+    echo "macOS users: brew install bash"
+    exit 1
+  fi
+
+  # Check oc authentication
+  if oc whoami &>/dev/null; then
+    :  # Already authenticated
+  else
+    echo ""
+    echo "============================================"
+    echo "ERROR: Not authenticated with Konflux"
+    echo "============================================"
+    echo "This script requires oc authentication."
+    echo "Run: oc login --web https://api.kflux-prd-rh02.0fk9.p1.openshiftapps.com:6443/"
+    echo ""
+    exit 1
+  fi
+
+  echo "✓ Prerequisites verified: bash 4.0+, oc, jq, curl, git"
+  echo "✓ Authenticated with Konflux as: $(oc whoami)"
+}
+
+# ============================================================================
+# Argument Parsing
+# ============================================================================
+
+parse_arguments() {
+  # Parse arguments (version, --stage/--prod - order-independent)
+  local ARG1="$1"
+  local ARG2="${2:-}"
+  local REST="${3:-}"
+
+  if [ -n "$REST" ]; then
+    echo "❌ ERROR: Too many arguments"
+    echo "Usage: $0 <version> [--stage|--prod]"
+    exit 1
+  fi
+
+  for arg in "$ARG1" "$ARG2"; do
+    [ -z "$arg" ] && continue
+
+    case "$arg" in
+      --stage|--prod)
+        RELEASE_TYPE="${arg#--}"
+        ;;
+      [0-9].[0-9]|[0-9].[0-9].[0-9]|[0-9].[0-9][0-9]|[0-9].[0-9][0-9].[0-9]|[0-9].[0-9][0-9].[0-9][0-9])
+        VERSION="$arg"
+        ;;
+      *)
+        echo "❌ ERROR: Unknown argument: $arg"
+        echo "Usage: $0 <version> [--stage|--prod]"
+        echo "Example: $0 0.22.1 --stage"
+        exit 1
+        ;;
+    esac
+  done
+
+  if [ -z "$VERSION" ]; then
+    echo "❌ ERROR: Version required"
+    echo "Usage: $0 <version> [--stage|--prod]"
+    echo "Example: $0 0.22.1 --stage"
+    exit 1
+  fi
+
+  # Validate version format
+  if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+ ]]; then
+    :  # Version format is valid
+  else
+    echo "❌ ERROR: Invalid version format: $VERSION"
+    echo "Expected: 0.Y or 0.Y.Z (e.g., 0.22 or 0.22.1)"
+    exit 1
+  fi
+
+  echo ""
+  echo "============================================"
+  echo "FBC $RELEASE_TYPE Release Creation"
+  echo "============================================"
+  echo "Version: $VERSION"
+  echo "Release type: $RELEASE_TYPE"
+  echo ""
+
+  # Find git repository root (allows running from anywhere in repo)
+  GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+  if [ -z "$GIT_ROOT" ]; then
+    echo "❌ ERROR: Not in a git repository"
+    exit 1
+  fi
+
+  # Set up paths relative to git root
+  SCRIPTS_DIR="$GIT_ROOT/scripts"
+  RELEASES_DIR="$GIT_ROOT/releases"
+
+  # Verify this is the correct repository by checking for required scripts
+  if [ -x "$SCRIPTS_DIR/verify-fbc-release.sh" ] && \
+     [ -x "$SCRIPTS_DIR/generate-fbc-release.sh" ]; then
+    :  # Scripts exist
+  else
+    echo "❌ ERROR: Required helper scripts not found"
+    echo "This skill requires the submariner-release-management repository"
+    echo "Looked in: $SCRIPTS_DIR"
+    exit 1
+  fi
+
+  echo "Repository root: $GIT_ROOT"
+  echo ""
+
+  # Check git status (working tree should be clean)
+  if git diff-index --quiet HEAD -- 2>/dev/null; then
+    :  # Working tree is clean
+  else
+    echo "⚠️  WARNING: Working tree has uncommitted changes"
+    echo "Proceeding anyway - you can review changes before pushing"
+    echo ""
+  fi
+}
+
+# ============================================================================
+# Verify Release Readiness
+# ============================================================================
+
+verify_release() {
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "Verifying FBC snapshots and component SHAs"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+
+  # Call combined verification script (batched queries + parallel extraction)
+  local COMBINED_JSON
+  COMBINED_JSON=$("$SCRIPTS_DIR/verify-fbc-release.sh" "$VERSION" 2>&1)
+  local VERIFY_EXIT=$?
+
+  if [ $VERIFY_EXIT -ne 0 ]; then
+    echo "$COMBINED_JSON"
+    echo ""
+    echo "❌ Verification failed"
+    exit 1
+  fi
+
+  # Extract JSON (single line) and diagnostic output (everything else)
+  local COMBINED_RESULT
+  COMBINED_RESULT=$(echo "$COMBINED_JSON" | tail -1)
+
+  # Show diagnostic output from script (all lines except JSON)
+  echo "$COMBINED_JSON" | head -n -1
+
+  # Parse JSON to verify status
+  local STATUS
+  STATUS=$(echo "$COMBINED_RESULT" | jq -r '.status' 2>/dev/null || echo "invalid")
+  if [ "$STATUS" != "pass" ]; then
+    echo "❌ Verification failed (invalid JSON output)"
+    exit 1
+  fi
+
+  # Extract snapshot names for each OCP version
+  for VERSION_NUM in 16 17 18 19 20 21; do
+    local SNAPSHOT
+    SNAPSHOT=$(echo "$COMBINED_RESULT" | jq -r ".snapshots[\"4-${VERSION_NUM}\"]")
+    SNAPSHOTS["4-${VERSION_NUM}"]="$SNAPSHOT"
+  done
+
+  echo ""
+}
+
+# ============================================================================
+# Generate Release YAMLs
+# ============================================================================
+
+generate_yamls() {
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "Generating Release YAMLs"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+
+  # Get release date
+  local RELEASE_DATE
+  RELEASE_DATE=$(date +%Y%m%d)
+
+  # Change to git root so generate script can use relative paths
+  cd "$GIT_ROOT" || exit 1
+
+  for OCP_VERSION in 16 17 18 19 20 21; do
+    # Get snapshot name from combined JSON
+    local SNAPSHOT="${SNAPSHOTS[4-${OCP_VERSION}]}"
+
+    echo "Generating 4-${OCP_VERSION} release..."
+
+    # Call generate-fbc-release.sh using absolute path
+    local YAML_FILE
+    YAML_FILE=$("$SCRIPTS_DIR/generate-fbc-release.sh" "4-${OCP_VERSION}" "$SNAPSHOT" "$RELEASE_TYPE" "$RELEASE_DATE")
+    local GENERATE_EXIT=$?
+
+    if [ $GENERATE_EXIT -ne 0 ]; then
+      echo "❌ Failed to generate YAML for 4-${OCP_VERSION}"
+      exit 1
+    fi
+
+    echo "  ✓ Created: $YAML_FILE"
+    CREATED_FILES+=("$YAML_FILE")
+  done
+
+  echo ""
+  echo "✓ Created 6 FBC ${RELEASE_TYPE} Release YAMLs"
+}
+
+# ============================================================================
+# Validate YAMLs
+# ============================================================================
+
+validate_yamls() {
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "Validating Release YAMLs"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+
+  local VALIDATION_FAILED=0
+
+  for YAML_FILE in "${CREATED_FILES[@]}"; do
+    echo "Validating $(basename "$YAML_FILE")..."
+
+    # Run make test-remote from git root using -C flag
+    if make -C "$GIT_ROOT" test-remote FILE="$YAML_FILE" >/dev/null 2>&1; then
+      echo "  ✓ Validation passed"
+    else
+      echo "  ✗ Validation failed"
+      ((VALIDATION_FAILED++))
+    fi
+  done
+
+  if [ $VALIDATION_FAILED -gt 0 ]; then
+    echo ""
+    echo "❌ $VALIDATION_FAILED YAML(s) failed validation"
+    echo "Run 'make -C $GIT_ROOT test-remote FILE=<yaml>' for details"
+    exit 1
+  fi
+
+  echo ""
+  echo "✓ All YAMLs passed validation"
+}
+
+# ============================================================================
+# Commit Changes
+# ============================================================================
+
+commit_changes() {
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "Creating commit"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+
+  # Stage all created files using absolute path
+  git add "$RELEASES_DIR/fbc/" || {
+    echo "❌ ERROR: Failed to stage files"
+    exit 1
+  }
+
+  # Show what's being committed
+  echo "Files to commit:"
+  git status --short | grep "^A" | sed 's/^A  /  /'
+  echo ""
+
+  # Create commit message
+  local COMMIT_MSG
+  COMMIT_MSG="Add FBC ${RELEASE_TYPE} releases for $VERSION
+
+Generated 6 Release CRs (OCP 4-16 through 4-21) with:
+- Verified GitHub catalog consistency
+- Verified FBC snapshots (push events, tests passed)
+- Verified component SHAs across all sources
+- Validated with make test-remote"
+
+  # Create commit
+  git commit -s -m "$COMMIT_MSG" || {
+    echo "❌ ERROR: Failed to create commit"
+    exit 1
+  }
+
+  local COMMIT_HASH
+  COMMIT_HASH=$(git rev-parse --short HEAD)
+
+  echo "✓ Commit created: $COMMIT_HASH"
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "SUCCESS - FBC ${RELEASE_TYPE} releases created"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+  echo "Next steps:"
+  echo ""
+  echo "1. Review changes:"
+  echo "   git show"
+  echo ""
+  echo "2. Push commit:"
+  echo "   git push origin \$(git rev-parse --abbrev-ref HEAD)"
+  echo ""
+  echo "3. Apply releases to cluster:"
+  for YAML_FILE in "${CREATED_FILES[@]}"; do
+    local YAML_NAME
+    YAML_NAME=$(basename "$YAML_FILE" .yaml)
+    echo "   make apply FILE=$YAML_FILE"
+    echo "   make watch NAME=$YAML_NAME"
+  done
+  echo ""
+  echo "To undo this commit:"
+  echo "   git reset HEAD~1"
+  echo ""
+}
+
+# ============================================================================
+# Main Execution
+# ============================================================================
+
+main() {
+  check_prerequisites
+  parse_arguments "$@"
+  verify_release
+  generate_yamls
+  validate_yamls
+  commit_changes
+}
+
+main "$@"

--- a/scripts/generate-fbc-release.sh
+++ b/scripts/generate-fbc-release.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# Generate single FBC Release YAML
+#
+# Usage: generate-fbc-release.sh <ocp-version> <snapshot-name> <release-type> <release-date>
+#
+# Arguments:
+#   ocp-version:    OCP version (e.g., 4-18)
+#   snapshot-name:  Snapshot name (e.g., submariner-fbc-4-18-abc123)
+#   release-type:   stage or prod
+#   release-date:   Release date in YYYYMMDD format
+#
+# Output: Path to created YAML file (stdout)
+# Exit codes:
+#   0: Success
+#   1: Failure (invalid arguments, directory creation failed, write failed)
+
+set -euo pipefail
+
+# Validate arguments
+if [ $# -ne 4 ]; then
+  echo "❌ ERROR: Invalid number of arguments" >&2
+  echo "Usage: $0 <ocp-version> <snapshot-name> <release-type> <release-date>" >&2
+  echo "Example: $0 4-18 submariner-fbc-4-18-abc123 stage 20260303" >&2
+  exit 1
+fi
+
+OCP_VERSION="$1"
+SNAPSHOT="$2"
+RELEASE_TYPE="$3"
+RELEASE_DATE="$4"
+
+# Validate OCP version format (4-16 through 4-21)
+if [[ "$OCP_VERSION" =~ ^4-(1[6-9]|2[0-1])$ ]]; then
+  :  # OCP version is valid
+else
+  echo "❌ ERROR: Invalid OCP version: $OCP_VERSION" >&2
+  echo "Expected: 4-16 through 4-21" >&2
+  exit 1
+fi
+
+# Validate release type
+if [[ "$RELEASE_TYPE" != "stage" && "$RELEASE_TYPE" != "prod" ]]; then
+  echo "❌ ERROR: Invalid release type: $RELEASE_TYPE" >&2
+  echo "Expected: stage or prod" >&2
+  exit 1
+fi
+
+# Validate release date format (YYYYMMDD)
+if [[ "$RELEASE_DATE" =~ ^[0-9]{8}$ ]]; then
+  :  # Release date format is valid
+else
+  echo "❌ ERROR: Invalid release date format: $RELEASE_DATE" >&2
+  echo "Expected: YYYYMMDD (e.g., 20260303)" >&2
+  exit 1
+fi
+
+# Validate snapshot name format
+if [[ "$SNAPSHOT" =~ ^submariner-fbc-${OCP_VERSION}- ]]; then
+  :  # Snapshot name format is valid
+else
+  echo "❌ ERROR: Snapshot name doesn't match OCP version" >&2
+  echo "Expected: submariner-fbc-${OCP_VERSION}-..." >&2
+  echo "Got: $SNAPSHOT" >&2
+  exit 1
+fi
+
+# Create directory if needed
+OUTPUT_DIR="releases/fbc/${OCP_VERSION}/${RELEASE_TYPE}"
+mkdir -p "$OUTPUT_DIR" || {
+  echo "❌ ERROR: Failed to create directory: $OUTPUT_DIR" >&2
+  exit 1
+}
+
+# Determine sequence number (check for existing files)
+SEQUENCE=1
+while [ -f "${OUTPUT_DIR}/submariner-fbc-${OCP_VERSION}-${RELEASE_TYPE}-${RELEASE_DATE}-$(printf '%02d' $SEQUENCE).yaml" ]; do
+  ((SEQUENCE++))
+done
+
+# Generate filename
+FILENAME="submariner-fbc-${OCP_VERSION}-${RELEASE_TYPE}-${RELEASE_DATE}-$(printf '%02d' $SEQUENCE).yaml"
+OUTPUT_FILE="${OUTPUT_DIR}/${FILENAME}"
+
+# Generate YAML content
+cat > "$OUTPUT_FILE" <<EOF
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-${OCP_VERSION}-${RELEASE_TYPE}-${RELEASE_DATE}-$(printf '%02d' $SEQUENCE)
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-${RELEASE_TYPE}-${OCP_VERSION}
+  snapshot: ${SNAPSHOT}
+EOF
+
+# Verify file was created
+if [ ! -f "$OUTPUT_FILE" ]; then
+  echo "❌ ERROR: Failed to create YAML file: $OUTPUT_FILE" >&2
+  exit 1
+fi
+
+# Verify file has expected content
+if ! grep -q "snapshot: ${SNAPSHOT}" "$OUTPUT_FILE"; then
+  echo "❌ ERROR: YAML file missing expected content" >&2
+  exit 1
+fi
+
+# Output the file path to stdout
+echo "$OUTPUT_FILE"

--- a/scripts/validate-release-data.sh
+++ b/scripts/validate-release-data.sh
@@ -41,13 +41,17 @@ validate_file() {
       fi
 
       # Validate CVE format: CVE-YYYY-NNNNN
-      if ! [[ "$cve" =~ ^CVE-[0-9]{4}-[0-9]{4,}$ ]]; then
+      if [[ "$cve" =~ ^CVE-[0-9]{4}-[0-9]{4,}$ ]]; then
+        :  # CVE format is valid
+      else
         echo "ERROR: Invalid CVE format '$cve' (expected CVE-YYYY-NNNNN)"
         exit 1
       fi
 
       # Validate component has version suffix: -X-Y
-      if ! [[ "$component" =~ -[0-9]+-[0-9]+$ ]]; then
+      if [[ "$component" =~ -[0-9]+-[0-9]+$ ]]; then
+        :  # Component version suffix is valid
+      else
         echo "ERROR: Component '$component' missing version suffix (expected -X-Y)"
         exit 1
       fi
@@ -86,14 +90,18 @@ validate_file() {
 
       if [[ "$source" == "issues.redhat.com" ]]; then
         # Jira format: PROJECT-NNNNN
-        if ! [[ "$id" =~ ^[A-Z]+-[0-9]+$ ]]; then
+        if [[ "$id" =~ ^[A-Z]+-[0-9]+$ ]]; then
+          :  # Jira ID format is valid
+        else
           echo "ERROR: Invalid Jira ID '$id' (expected PROJECT-NNNNN)"
           exit 1
         fi
         echo "  ✓ $id (Jira format valid)"
       elif [[ "$source" == "bugzilla.redhat.com" ]]; then
         # Bugzilla format: numeric only
-        if ! [[ "$id" =~ ^[0-9]+$ ]]; then
+        if [[ "$id" =~ ^[0-9]+$ ]]; then
+          :  # Bugzilla ID format is valid
+        else
           echo "ERROR: Invalid Bugzilla ID '$id' (expected numeric)"
           exit 1
         fi

--- a/scripts/verify-fbc-release.sh
+++ b/scripts/verify-fbc-release.sh
@@ -1,0 +1,582 @@
+#!/bin/bash
+# Verify FBC release readiness (combined snapshot + component SHA verification)
+#
+# Usage: verify-fbc-release.sh <version>
+#
+# Arguments:
+#   version: Submariner version (e.g., 0.22.1 or 0.22)
+#
+# Output: JSON with combined verification results (stdout)
+# Exit codes:
+#   0: Success (all verifications passed)
+#   1: Failure (any verification failed)
+#
+# Optimizations:
+#   - Batched OC queries: 1 API call instead of 30
+#   - Single-pass extraction: Extract each snapshot once (not twice)
+#   - Parallel extraction: 6 simultaneous extracts (added in Phase 2)
+
+set -euo pipefail
+
+# ============================================================================
+# Argument Parsing and Setup
+# ============================================================================
+
+# Validate arguments
+if [ $# -ne 1 ]; then
+  echo "❌ ERROR: Invalid number of arguments" >&2
+  echo "Usage: $0 <version>" >&2
+  echo "Example: $0 0.22.1" >&2
+  exit 1
+fi
+
+VERSION_INPUT="$1"
+
+# Extract major.minor (0.22.1 → 0.22)
+if [[ "$VERSION_INPUT" =~ ^[0-9]+\.[0-9]+ ]]; then
+  :  # Version format is valid
+else
+  echo "❌ ERROR: Invalid version format: $VERSION_INPUT" >&2
+  echo "Expected: 0.Y or 0.Y.Z (e.g., 0.22 or 0.22.1)" >&2
+  exit 1
+fi
+
+# Extract version components
+MAJOR_MINOR=$(echo "$VERSION_INPUT" | grep -oP '^\d+\.\d+')
+FULL_VERSION="$VERSION_INPUT"
+MAJOR=$(echo "$MAJOR_MINOR" | cut -d. -f1)
+MINOR=$(echo "$MAJOR_MINOR" | cut -d. -f2)
+HYPHENATED="${MAJOR}-${MINOR}"  # 0-22
+
+# Single tmpdir with trap cleanup
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "=== FBC Release Verification ===" >&2
+echo "Version: $FULL_VERSION (branch: release-$MAJOR_MINOR, components: *-$HYPHENATED)" >&2
+echo "" >&2
+
+# ============================================================================
+# Parallel Job Execution Helpers
+# ============================================================================
+
+# Run a job in background with error tracking
+run_parallel_job() {
+    local job_name="$1"
+    local job_func="$2"
+    shift 2
+    (
+        set -euo pipefail
+        EXIT_CODE=0
+        "${job_func}" "$@" 2>"$TMPDIR/${job_name}.stderr" || EXIT_CODE=$?
+        echo "$EXIT_CODE" > "$TMPDIR/${job_name}.exit"
+    ) &
+    echo "$!" >> "$TMPDIR/pids.txt"
+}
+
+# Wait for all parallel jobs and check for errors
+wait_parallel_jobs() {
+    local job_description="$1"
+
+    # Wait for all background jobs
+    while read -r pid; do
+        wait "$pid" || true  # Don't exit on individual job failure
+    done < "$TMPDIR/pids.txt"
+
+    # Check for errors after all jobs complete
+    local failed_count=0
+    local error_msg=""
+    local exit_code
+    local job_name
+    local stderr
+    for exit_file in "$TMPDIR"/*.exit; do
+        [ -f "$exit_file" ] || continue
+        exit_code=$(cat "$exit_file")
+        if [ "$exit_code" -ne 0 ]; then
+            ((failed_count++))
+            job_name=$(basename "$exit_file" .exit)
+            stderr=$(cat "${exit_file%.exit}.stderr" 2>/dev/null || echo "")
+            error_msg="${error_msg}  ${job_name}: ${stderr}\n"
+        fi
+    done
+
+    if [ $failed_count -gt 0 ]; then
+        echo "" >&2
+        echo "❌ ERROR: $failed_count $job_description job(s) failed:" >&2
+        echo -e "$error_msg" >&2
+        return 1
+    fi
+
+    # Clean up for next parallel batch
+    rm -f "$TMPDIR/pids.txt" "$TMPDIR"/*.exit "$TMPDIR"/*.stderr 2>/dev/null || true
+}
+
+# ============================================================================
+# Step 1: Verify GitHub Catalog Consistency
+# ============================================================================
+
+echo "Step 1: Verifying GitHub catalog consistency..." >&2
+
+declare -A BUNDLE_SHAS
+FAILED=0
+
+for VERSION in 16 17 18 19 20 21; do
+  CATALOG_URL="https://raw.githubusercontent.com/stolostron/submariner-operator-fbc/main/catalog-4-${VERSION}/bundles/bundle-v${FULL_VERSION}.yaml"
+
+  # Fetch bundle and extract SHA
+  BUNDLE_SHA=$(curl -sf "$CATALOG_URL" | grep "^image:" | head -1 | grep -oP 'sha256:\K[a-f0-9]+' || true)
+
+  if [ -z "$BUNDLE_SHA" ]; then
+    echo "  4-${VERSION}: ✗ Failed to fetch bundle or extract SHA" >&2
+    echo "    URL: $CATALOG_URL" >&2
+    ((FAILED++))
+    continue
+  fi
+
+  BUNDLE_SHAS["4-${VERSION}"]="$BUNDLE_SHA"
+  echo "  4-${VERSION}: ${BUNDLE_SHA:0:12}..." >&2
+done
+
+# Check if all SHAs are the same
+if [ $FAILED -eq 0 ]; then
+  UNIQUE_SHAS=$(printf '%s\n' "${BUNDLE_SHAS[@]}" | sort -u | wc -l)
+
+  if [ "$UNIQUE_SHAS" -ne 1 ]; then
+    echo "" >&2
+    echo "✗ ERROR: FBC catalog bundle SHA mismatch:" >&2
+    for VERSION in 16 17 18 19 20 21; do
+      echo "  4-${VERSION}: ${BUNDLE_SHAS[4-${VERSION}]}" >&2
+    done
+    echo "" >&2
+    echo "Remediation:" >&2
+    echo "1. Check if Step 11 (FBC catalog update) completed correctly" >&2
+    echo "2. Verify all 6 catalogs were updated with same bundle SHA" >&2
+    echo "3. Re-run Step 11 if needed" >&2
+    exit 1
+  fi
+
+  # Get the common SHA
+  EXPECTED_BUNDLE_SHA="${BUNDLE_SHAS[4-16]}"
+  echo "" >&2
+  echo "✓ Bundle SHA consistent across all 6 GitHub catalogs: ${EXPECTED_BUNDLE_SHA:0:12}..." >&2
+else
+  echo "" >&2
+  echo "✗ ERROR: Failed to fetch $FAILED catalog(s)" >&2
+  exit 1
+fi
+
+# ============================================================================
+# Step 2: Batch Fetch All Snapshots (OPTIMIZATION: 1 query vs 30)
+# ============================================================================
+
+echo "" >&2
+echo "Step 2: Fetching FBC snapshots (batched query)..." >&2
+
+# ONE query for all snapshots (vs 6 list + 24 individual gets)
+ALL_SNAPSHOTS=$(oc get snapshots -n submariner-tenant -o json 2>/dev/null)
+
+# Save for debugging
+echo "$ALL_SNAPSHOTS" > "$TMPDIR/snapshots.json"
+
+# Extract data for each OCP version using jq (local filtering, no API calls)
+declare -A SNAPSHOTS
+declare -A CATALOG_IMAGES
+declare -A EVENT_TYPES
+declare -A TEST_STATUSES
+
+FAILED=0
+FAILED_DETAILS=""
+
+for VERSION in 16 17 18 19 20 21; do
+  # Filter for this version, get latest (all in one jq query)
+  SNAPSHOT_DATA=""
+  SNAPSHOT_DATA=$(echo "$ALL_SNAPSHOTS" | jq -r \
+    ".items[] | select(.metadata.name | startswith(\"submariner-fbc-4-${VERSION}\")) |
+    select(.metadata.creationTimestamp != null) |
+    {name: .metadata.name,
+     event: .metadata.annotations[\"pac.test.appstudio.openshift.io/event-type\"],
+     tests: .metadata.annotations[\"test.appstudio.openshift.io/status\"],
+     image: .spec.components[0].containerImage,
+     timestamp: .metadata.creationTimestamp} |
+    @json" | jq -s 'sort_by(.timestamp) | last')
+
+  if [ -z "$SNAPSHOT_DATA" ] || [ "$SNAPSHOT_DATA" = "null" ]; then
+    echo "  4-${VERSION}: ✗ No snapshot found" >&2
+    FAILED_DETAILS="${FAILED_DETAILS}    4-${VERSION}: No snapshot found\n"
+    ((FAILED++))
+    continue
+  fi
+
+  # Parse JSON into associative arrays
+  SNAPSHOTS["4-${VERSION}"]=$(echo "$SNAPSHOT_DATA" | jq -r '.name')
+  CATALOG_IMAGES["4-${VERSION}"]=$(echo "$SNAPSHOT_DATA" | jq -r '.image')
+  EVENT_TYPES["4-${VERSION}"]=$(echo "$SNAPSHOT_DATA" | jq -r '.event // "unknown"')
+  TEST_STATUSES["4-${VERSION}"]=$(echo "$SNAPSHOT_DATA" | jq -r '.tests // "{}"')
+
+  echo "  4-${VERSION}: ${SNAPSHOTS[4-${VERSION}]}" >&2
+done
+
+if [ $FAILED -gt 0 ]; then
+  echo "" >&2
+  echo "✗ ERROR: Failed to find $FAILED snapshot(s):" >&2
+  echo -e "$FAILED_DETAILS" >&2
+  exit 1
+fi
+
+echo "" >&2
+echo "✓ Found all 6 FBC snapshots" >&2
+
+# ============================================================================
+# Step 3: Single-Pass Bundle Extraction (OPTIMIZATION: Parallel + extract once)
+# ============================================================================
+
+echo "" >&2
+echo "Step 3: Extracting bundles from snapshots (parallel, single-pass)..." >&2
+
+# Extract each snapshot's bundle ONCE (not twice like old scripts)
+# Use parallel execution for 6 simultaneous extractions
+# Bundle YAMLs stay in tmpdir for both bundle SHA AND component SHA verification
+
+# Define extraction function for parallel execution
+extract_single_bundle() {
+    local VERSION="$1"
+    local SNAPSHOT="$2"
+    local CATALOG_IMAGE="$3"
+    local FULL_VERSION="$4"
+
+    # Each version gets own directory
+    local EXTRACT_DIR="$TMPDIR/extract-4-${VERSION}"
+    mkdir -p "$EXTRACT_DIR"
+
+    # Extract bundle YAML (suppress output)
+    oc image extract "$CATALOG_IMAGE" \
+        --path "/configs/submariner/bundles/bundle-v${FULL_VERSION}.yaml:$EXTRACT_DIR/" \
+        --confirm > /dev/null 2>&1
+
+    # Verify file exists and extract SHA
+    local BUNDLE_YAML="$EXTRACT_DIR/bundle-v${FULL_VERSION}.yaml"
+    if [ ! -f "$BUNDLE_YAML" ]; then
+        echo "Failed to extract bundle from $SNAPSHOT" >&2
+        return 1
+    fi
+
+    local SNAPSHOT_BUNDLE_SHA
+    SNAPSHOT_BUNDLE_SHA=$(grep "^image:" "$BUNDLE_YAML" | head -1 | grep -oP 'sha256:\K[a-f0-9]+' || true)
+    if [ -z "$SNAPSHOT_BUNDLE_SHA" ]; then
+        echo "Failed to extract SHA from bundle" >&2
+        return 1
+    fi
+
+    # Save SHA for later use
+    echo "$SNAPSHOT_BUNDLE_SHA" > "$EXTRACT_DIR/bundle-sha.txt"
+
+    echo "  4-${VERSION}: ✓ ${SNAPSHOT_BUNDLE_SHA:0:12}..." >&2
+}
+
+# Export function and variables for subshells
+export -f extract_single_bundle
+export TMPDIR FULL_VERSION
+
+# Launch parallel extraction jobs
+for VERSION in 16 17 18 19 20 21; do
+    run_parallel_job "extract-4-${VERSION}" extract_single_bundle \
+        "$VERSION" "${SNAPSHOTS[4-${VERSION}]}" "${CATALOG_IMAGES[4-${VERSION}]}" "$FULL_VERSION"
+done
+
+# Wait for all extractions to complete and check for errors
+if ! wait_parallel_jobs "bundle extraction"; then
+    echo "" >&2
+    echo "✗ ERROR: Bundle extraction failed" >&2
+    exit 1
+fi
+
+echo "" >&2
+echo "✓ Extracted all 6 bundles (parallel, single-pass)" >&2
+
+# ============================================================================
+# Step 4: Verify Snapshot Readiness
+# ============================================================================
+
+echo "" >&2
+echo "Step 4: Verifying snapshot readiness..." >&2
+
+declare -A VERIFIED_SNAPSHOTS
+FAILED=0
+FAILED_DETAILS=""
+
+for VERSION in 16 17 18 19 20 21; do
+  SNAPSHOT="${SNAPSHOTS[4-${VERSION}]}"
+  EVENT_TYPE="${EVENT_TYPES[4-${VERSION}]}"
+  TESTS_JSON="${TEST_STATUSES[4-${VERSION}]}"
+  SNAPSHOT_BUNDLE_SHA=$(cat "$TMPDIR/extract-4-${VERSION}/bundle-sha.txt")
+
+  # Verify event type
+  if [ "$EVENT_TYPE" != "push" ]; then
+    echo "  4-${VERSION}: ✗ Event type '$EVENT_TYPE' (must be 'push')" >&2
+    FAILED_DETAILS="${FAILED_DETAILS}    4-${VERSION}: Event type '$EVENT_TYPE' (must be 'push', not PR)\n"
+    ((FAILED++))
+    continue
+  fi
+
+  # Verify tests passed
+  if [ -z "$TESTS_JSON" ] || [ "$TESTS_JSON" = "{}" ]; then
+    echo "  4-${VERSION}: ✗ No test status" >&2
+    FAILED_DETAILS="${FAILED_DETAILS}    4-${VERSION}: No test status\n"
+    ((FAILED++))
+    continue
+  fi
+
+  # Check for any non-passing tests
+  FAILED_TESTS=$(echo "$TESTS_JSON" | jq -r '.[] | select(.status != "TestPassed") | .scenario' 2>/dev/null || true)
+  if [ -n "$FAILED_TESTS" ]; then
+    echo "  4-${VERSION}: ✗ Tests failed: $FAILED_TESTS" >&2
+    FAILED_DETAILS="${FAILED_DETAILS}    4-${VERSION}: Tests failed: $FAILED_TESTS\n"
+    ((FAILED++))
+    continue
+  fi
+
+  # Verify bundle SHA matches GitHub
+  if [ "$SNAPSHOT_BUNDLE_SHA" != "$EXPECTED_BUNDLE_SHA" ]; then
+    echo "  4-${VERSION}: ✗ Bundle SHA mismatch (snapshot: ${SNAPSHOT_BUNDLE_SHA:0:12}, expected: ${EXPECTED_BUNDLE_SHA:0:12})" >&2
+    FAILED_DETAILS="${FAILED_DETAILS}    4-${VERSION}: Bundle SHA mismatch\n"
+    ((FAILED++))
+    continue
+  fi
+
+  # All checks passed
+  echo "  4-${VERSION}: ✓ $SNAPSHOT (push, tests passed, bundle SHA verified)" >&2
+  VERIFIED_SNAPSHOTS["4-${VERSION}"]="$SNAPSHOT"
+done
+
+if [ $FAILED -gt 0 ]; then
+  echo "" >&2
+  echo "✗ ERROR: Snapshot verification failed for $FAILED version(s):" >&2
+  echo -e "$FAILED_DETAILS" >&2
+  echo "Remediation:" >&2
+  echo "1. Wait for FBC rebuild after Step 11 merge (~15-30 min)" >&2
+  echo "2. Check: oc get snapshots -n submariner-tenant | grep fbc" >&2
+  echo "3. Verify event type and test status" >&2
+  exit 1
+fi
+
+echo "" >&2
+echo "✓ All 6 FBC snapshots ready for release" >&2
+
+# ============================================================================
+# Step 5: Extract Bundle Metadata (Source Commit)
+# ============================================================================
+
+echo "" >&2
+echo "Step 5: Extracting bundle source commit..." >&2
+
+# Get bundle image URL from FBC catalog (using 4-21 as representative - all verified identical)
+BUNDLE_IMAGE=$(curl -sf "https://raw.githubusercontent.com/stolostron/submariner-operator-fbc/main/catalog-4-21/bundles/bundle-v${FULL_VERSION}.yaml" | grep "^image:" | head -1 | awk '{print $2}' || true)
+
+if [ -z "$BUNDLE_IMAGE" ]; then
+  echo "❌ ERROR: Failed to fetch bundle image URL from FBC catalog" >&2
+  echo "URL: https://raw.githubusercontent.com/stolostron/submariner-operator-fbc/main/catalog-4-21/bundles/bundle-v${FULL_VERSION}.yaml" >&2
+  exit 1
+fi
+
+# Verify bundle SHA matches expected
+BUNDLE_IMAGE_SHA=$(echo "$BUNDLE_IMAGE" | grep -oP 'sha256:\K[a-f0-9]+' || true)
+if [ "$BUNDLE_IMAGE_SHA" != "$EXPECTED_BUNDLE_SHA" ]; then
+  echo "❌ ERROR: Bundle SHA mismatch" >&2
+  echo "  Expected (from snapshots): ${EXPECTED_BUNDLE_SHA:0:12}" >&2
+  echo "  Found (in FBC catalog):    ${BUNDLE_IMAGE_SHA:0:12}" >&2
+  exit 1
+fi
+
+echo "  ✓ Bundle image: $BUNDLE_IMAGE" >&2
+
+# Extract source commit from OCI labels (try registry.redhat.io first, fallback to quay.io)
+SOURCE_COMMIT=$(skopeo inspect "docker://${BUNDLE_IMAGE}" 2>/dev/null | jq -r '.Labels."org.opencontainers.image.revision"' || true)
+
+if [ -z "$SOURCE_COMMIT" ] || [ "$SOURCE_COMMIT" = "null" ]; then
+  # Fallback: try quay.io workspace URL from template
+  echo "  ⚠ Bundle not found at ${BUNDLE_IMAGE%%@*}, trying quay.io workspace..." >&2
+  BUNDLE_IMAGE_QUAY=$(curl -sf "https://raw.githubusercontent.com/stolostron/submariner-operator-fbc/main/catalog-template.yaml" | grep -A1 "name: submariner.v${FULL_VERSION}" | grep "image:" | awk '{print $2}' || true)
+
+  if [ -n "$BUNDLE_IMAGE_QUAY" ]; then
+    SOURCE_COMMIT=$(skopeo inspect "docker://${BUNDLE_IMAGE_QUAY}" 2>/dev/null | jq -r '.Labels."org.opencontainers.image.revision"' || true)
+    if [ -n "$SOURCE_COMMIT" ] && [ "$SOURCE_COMMIT" != "null" ]; then
+      echo "  ✓ Using quay.io bundle: $BUNDLE_IMAGE_QUAY" >&2
+      BUNDLE_IMAGE="$BUNDLE_IMAGE_QUAY"
+    fi
+  fi
+fi
+
+if [ -z "$SOURCE_COMMIT" ] || [ "$SOURCE_COMMIT" = "null" ]; then
+  echo "❌ ERROR: Failed to extract source commit from bundle image" >&2
+  echo "Image (registry.redhat.io): $BUNDLE_IMAGE" >&2
+  echo "Image (quay.io fallback): ${BUNDLE_IMAGE_QUAY:-NOT FOUND}" >&2
+  exit 1
+fi
+
+echo "  ✓ Source commit: $SOURCE_COMMIT" >&2
+
+# ============================================================================
+# Step 6: Fetch Operator CSV from Source Commit
+# ============================================================================
+
+echo "" >&2
+echo "Step 6: Fetching operator CSV from commit ${SOURCE_COMMIT:0:7}..." >&2
+
+# Fetch CSV from specific commit (not branch HEAD)
+OP_CSV=$(curl -sf "https://raw.githubusercontent.com/submariner-io/submariner-operator/${SOURCE_COMMIT}/bundle/manifests/submariner.clusterserviceversion.yaml")
+if [ -z "$OP_CSV" ]; then
+  echo "❌ ERROR: Failed to fetch operator CSV from source commit" >&2
+  echo "URL: https://raw.githubusercontent.com/submariner-io/submariner-operator/${SOURCE_COMMIT}/bundle/manifests/submariner.clusterserviceversion.yaml" >&2
+  exit 1
+fi
+
+echo "  ✓ Fetched operator CSV from commit ${SOURCE_COMMIT:0:7}" >&2
+
+# Fetch FBC bundle for comparison (using 4-21 as representative - all 6 catalogs verified identical)
+FBC_BUNDLE=$(curl -sf "https://raw.githubusercontent.com/stolostron/submariner-operator-fbc/main/catalog-4-21/bundles/bundle-v${FULL_VERSION}.yaml")
+if [ -z "$FBC_BUNDLE" ]; then
+  echo "❌ ERROR: Failed to fetch FBC bundle from GitHub" >&2
+  echo "URL: https://raw.githubusercontent.com/stolostron/submariner-operator-fbc/main/catalog-4-21/bundles/bundle-v${FULL_VERSION}.yaml" >&2
+  exit 1
+fi
+
+echo "  ✓ Fetched FBC GitHub bundle" >&2
+
+# ============================================================================
+# Step 7: Verify Component SHAs Across All Sources
+# ============================================================================
+
+echo "" >&2
+echo "Step 7: Verifying component SHAs across all sources..." >&2
+
+# Component list with CSV name mappings
+declare -A CSV_NAMES
+CSV_NAMES["submariner-operator"]="submariner-operator"
+CSV_NAMES["submariner-gateway"]="submariner-gateway"
+CSV_NAMES["submariner-globalnet"]="submariner-globalnet"
+CSV_NAMES["submariner-route-agent"]="submariner-routeagent"  # Note: routeagent (no dash)
+CSV_NAMES["lighthouse-agent"]="submariner-lighthouse-agent"
+CSV_NAMES["lighthouse-coredns"]="submariner-lighthouse-coredns"
+CSV_NAMES["nettest"]="submariner-nettest"
+
+MISMATCH=0
+declare -A COMPONENT_RESULTS
+
+for COMP in submariner-operator submariner-gateway submariner-globalnet submariner-route-agent lighthouse-agent lighthouse-coredns nettest; do
+  CSV="${CSV_NAMES[$COMP]}"
+
+  # Extract SHA from operator repo and FBC catalog (GitHub)
+  # Special case for nettest: it has no name field, match by image URL pattern
+  if [ "$COMP" = "nettest" ]; then
+    OP_SHA=$(echo "$OP_CSV" | awk '/relatedImages:/,/selector:/' | grep "nettest-rhel9" | grep -oP 'sha256:\K[a-f0-9]+' | head -1 || true)
+    FBC_SHA=$(echo "$FBC_BUNDLE" | awk '/relatedImages:/,/schema:/' | grep "nettest-rhel9" | grep -oP 'sha256:\K[a-f0-9]+' | head -1 || true)
+  else
+    OP_SHA=$(echo "$OP_CSV" | awk '/relatedImages:/,/selector:/' | grep -B1 "name: $CSV" | grep -oP 'sha256:\K[a-f0-9]+' || true)
+    FBC_SHA=$(echo "$FBC_BUNDLE" | awk '/relatedImages:/,/schema:/' | grep -B1 "name: $CSV" | grep -oP 'sha256:\K[a-f0-9]+' || true)
+  fi
+
+  # Check if extraction succeeded
+  if [ -z "$OP_SHA" ] || [ -z "$FBC_SHA" ]; then
+    echo "  $COMP: ✗ SHA extraction failed" >&2
+    echo "    Operator CSV (commit ${SOURCE_COMMIT:0:7}): ${OP_SHA:-NOT FOUND}" >&2
+    echo "    FBC bundle (v${FULL_VERSION}): ${FBC_SHA:-NOT FOUND}" >&2
+    COMPONENT_RESULTS[$COMP]="fail"
+    ((MISMATCH++))
+    continue
+  fi
+
+  # Verify all 6 FBC snapshots have same SHA as operator repo (using extracted bundles)
+  SNAP_MISMATCH=0
+  for VERSION in 16 17 18 19 20 21; do
+    SNAPSHOT="${SNAPSHOTS[4-${VERSION}]}"
+    BUNDLE_YAML="$TMPDIR/extract-4-${VERSION}/bundle-v${FULL_VERSION}.yaml"
+
+    # Special case for nettest: match by image URL pattern
+    if [ "$COMP" = "nettest" ]; then
+      SNAP_SHA=$(awk '/relatedImages:/,/schema:/' "$BUNDLE_YAML" | grep "nettest-rhel9" | grep -oP 'sha256:\K[a-f0-9]+' | head -1 || true)
+    else
+      SNAP_SHA=$(awk '/relatedImages:/,/schema:/' "$BUNDLE_YAML" | grep -B1 "name: $CSV" | grep -oP 'sha256:\K[a-f0-9]+' || true)
+    fi
+
+    if [ -z "$SNAP_SHA" ]; then
+      echo "  $COMP: ✗ Failed to extract SHA from snapshot $SNAPSHOT" >&2
+      ((SNAP_MISMATCH++))
+    elif [ "$SNAP_SHA" != "$OP_SHA" ]; then
+      echo "  $COMP: ✗ Snapshot $SNAPSHOT SHA mismatch (${SNAP_SHA:0:12} vs ${OP_SHA:0:12})" >&2
+      ((SNAP_MISMATCH++))
+    fi
+  done
+
+  if [ $SNAP_MISMATCH -gt 0 ]; then
+    COMPONENT_RESULTS[$COMP]="fail"
+    ((MISMATCH++))
+    continue
+  fi
+
+  # Verify operator repo and FBC GitHub match
+  if [ "$OP_SHA" != "$FBC_SHA" ]; then
+    echo "  $COMP: ✗ SHA mismatch" >&2
+    echo "    Operator repo:  ${OP_SHA:0:12}" >&2
+    echo "    FBC GitHub:     ${FBC_SHA:0:12}" >&2
+    COMPONENT_RESULTS[$COMP]="fail"
+    ((MISMATCH++))
+    continue
+  fi
+
+  echo "  $COMP: ✓ ${OP_SHA:0:12}... (verified across all sources)" >&2
+  COMPONENT_RESULTS[$COMP]="pass:${OP_SHA}"
+done
+
+# Summary
+if [ $MISMATCH -gt 0 ]; then
+  echo "" >&2
+  echo "✗ $MISMATCH component(s) failed verification" >&2
+  echo "" >&2
+  echo "Remediation:" >&2
+  echo "1. Verify Step 7 (update bundle SHAs) completed at commit $SOURCE_COMMIT" >&2
+  echo "2. Check bundle CSV: https://github.com/submariner-io/submariner-operator/blob/${SOURCE_COMMIT}/bundle/manifests/submariner.clusterserviceversion.yaml" >&2
+  echo "3. If SHAs don't match, re-run Step 7 (bundle SHA update)" >&2
+  echo "4. If SHAs don't match FBC catalog, re-run Step 11 (FBC catalog update)" >&2
+  exit 1
+fi
+
+echo "" >&2
+echo "✓ All 7 components verified (operator commit ${SOURCE_COMMIT:0:7}, FBC GitHub, 6 FBC snapshots)" >&2
+
+# ============================================================================
+# Step 8: Output Combined JSON
+# ============================================================================
+
+# Extract component data (format: "pass:SHA")
+OP_STATUS=$(echo "${COMPONENT_RESULTS[submariner-operator]}" | cut -d: -f1)
+OP_SHA=$(echo "${COMPONENT_RESULTS[submariner-operator]}" | cut -d: -f2)
+GW_STATUS=$(echo "${COMPONENT_RESULTS[submariner-gateway]}" | cut -d: -f1)
+GW_SHA=$(echo "${COMPONENT_RESULTS[submariner-gateway]}" | cut -d: -f2)
+GL_STATUS=$(echo "${COMPONENT_RESULTS[submariner-globalnet]}" | cut -d: -f1)
+GL_SHA=$(echo "${COMPONENT_RESULTS[submariner-globalnet]}" | cut -d: -f2)
+RA_STATUS=$(echo "${COMPONENT_RESULTS[submariner-route-agent]}" | cut -d: -f1)
+RA_SHA=$(echo "${COMPONENT_RESULTS[submariner-route-agent]}" | cut -d: -f2)
+LA_STATUS=$(echo "${COMPONENT_RESULTS[lighthouse-agent]}" | cut -d: -f1)
+LA_SHA=$(echo "${COMPONENT_RESULTS[lighthouse-agent]}" | cut -d: -f2)
+LC_STATUS=$(echo "${COMPONENT_RESULTS[lighthouse-coredns]}" | cut -d: -f1)
+LC_SHA=$(echo "${COMPONENT_RESULTS[lighthouse-coredns]}" | cut -d: -f2)
+NT_STATUS=$(echo "${COMPONENT_RESULTS[nettest]}" | cut -d: -f1)
+NT_SHA=$(echo "${COMPONENT_RESULTS[nettest]}" | cut -d: -f2)
+
+# Output JSON to stdout (single line for easy parsing)
+printf '{"status":"pass","bundle_sha":"%s","source_commit":"%s","snapshots":{"4-16":"%s","4-17":"%s","4-18":"%s","4-19":"%s","4-20":"%s","4-21":"%s"},"components":{"submariner-operator":{"status":"%s","sha":"%s"},"submariner-gateway":{"status":"%s","sha":"%s"},"submariner-globalnet":{"status":"%s","sha":"%s"},"submariner-route-agent":{"status":"%s","sha":"%s"},"lighthouse-agent":{"status":"%s","sha":"%s"},"lighthouse-coredns":{"status":"%s","sha":"%s"},"nettest":{"status":"%s","sha":"%s"}}}\n' \
+  "$EXPECTED_BUNDLE_SHA" \
+  "$SOURCE_COMMIT" \
+  "${VERIFIED_SNAPSHOTS[4-16]}" \
+  "${VERIFIED_SNAPSHOTS[4-17]}" \
+  "${VERIFIED_SNAPSHOTS[4-18]}" \
+  "${VERIFIED_SNAPSHOTS[4-19]}" \
+  "${VERIFIED_SNAPSHOTS[4-20]}" \
+  "${VERIFIED_SNAPSHOTS[4-21]}" \
+  "$OP_STATUS" "$OP_SHA" \
+  "$GW_STATUS" "$GW_SHA" \
+  "$GL_STATUS" "$GL_SHA" \
+  "$RA_STATUS" "$RA_SHA" \
+  "$LA_STATUS" "$LA_SHA" \
+  "$LC_STATUS" "$LC_SHA" \
+  "$NT_STATUS" "$NT_SHA"

--- a/skills/create-fbc-release/SKILL.md
+++ b/skills/create-fbc-release/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: create-fbc-release
+description: Create FBC releases for all OCP versions (stage or prod) with comprehensive verification
+version: 1.0.0
+argument-hint: "<version> [--stage|--prod]"
+user-invocable: true
+allowed-tools: Bash
+---
+
+# Create FBC Releases
+
+Automates Step 12 (FBC stage releases) and Step 17 (FBC prod releases) of the Submariner release workflow.
+
+**What it does:**
+
+- Verifies GitHub catalog consistency (all 6 OCP versions)
+- Verifies FBC snapshots (event type, tests, bundle SHAs)
+- Verifies component SHAs across 10 sources (operator repo, registry bundle, FBC GitHub, 6 snapshots)
+- Generates 6 Release YAMLs (one per OCP version: 4-16 through 4-21)
+- Validates YAMLs with make test-remote
+- Automatically commits with descriptive message
+
+**Usage:**
+
+```bash
+/create-fbc-release 0.22.1 --stage   # Create stage releases
+/create-fbc-release 0.22.1 --prod    # Create prod releases
+/create-fbc-release 0.22 --stage     # Auto-detects latest patch version
+/create-fbc-release 0.22             # Defaults to stage
+```
+
+**Prerequisites:**
+
+- oc login (required for snapshot queries)
+- Step 10 complete (component stage release)
+- Step 11 complete (FBC catalog updated)
+- FBC snapshots rebuilt (~15-30 min after Step 11)
+
+**Arguments:** $ARGUMENTS
+
+---
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# Find git repository root
+GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$GIT_ROOT" ]; then
+  echo "❌ ERROR: Not in a git repository"
+  exit 1
+fi
+
+# Verify orchestrator script exists
+if [ ! -x "$GIT_ROOT/scripts/create-fbc-releases.sh" ]; then
+  echo "❌ ERROR: Required orchestrator script not found"
+  echo "This skill requires: scripts/create-fbc-releases.sh"
+  exit 1
+fi
+
+# Delegate to orchestrator (passes all arguments)
+exec "$GIT_ROOT/scripts/create-fbc-releases.sh" $ARGUMENTS
+```


### PR DESCRIPTION
Automates Steps 12 and 17 of the Submariner release workflow with two
equivalent interfaces - a Claude skill and a make target - both
replacing manual YAML creation and verification with a single command.

- Verifies catalog consistency across all 6 OCP versions (4-16 to 4-21)
- Validates FBC snapshots (event type, test status, bundle SHAs)
- Cross-verifies component SHAs across 10 sources (operator repo,
  registry, GitHub catalogs, and all snapshot catalogs)
- Generates 6 Release YAMLs with automatic validation
- Commits changes with descriptive message

Implementation:
- New skill: skills/create-fbc-release/SKILL.md
- New make target: create-fbc-releases
- Orchestrator: scripts/create-fbc-releases.sh
- Generator: scripts/generate-fbc-release.sh
- Verifier: scripts/verify-fbc-release.sh
- Updates: Makefile, CLAUDE.md, README.md, .claude/SKILLS.md

Usage (either interface):
        /create-fbc-release 0.22.1 --stage
        make create-fbc-releases VERSION=0.22.1 TYPE=stage