### PR TITLE
Add FBC stage releases for 0.22.1

### DIFF
--- a/releases/fbc/4-16/stage/submariner-fbc-4-16-stage-20260304-01.yaml
+++ b/releases/fbc/4-16/stage/submariner-fbc-4-16-stage-20260304-01.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-16-stage-20260304-01
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-stage-4-16
+  snapshot: submariner-fbc-4-16-20260303-205332-000

--- a/releases/fbc/4-17/stage/submariner-fbc-4-17-stage-20260304-01.yaml
+++ b/releases/fbc/4-17/stage/submariner-fbc-4-17-stage-20260304-01.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-17-stage-20260304-01
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-stage-4-17
+  snapshot: submariner-fbc-4-17-20260303-205333-000

--- a/releases/fbc/4-18/stage/submariner-fbc-4-18-stage-20260304-01.yaml
+++ b/releases/fbc/4-18/stage/submariner-fbc-4-18-stage-20260304-01.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-18-stage-20260304-01
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-stage-4-18
+  snapshot: submariner-fbc-4-18-20260303-205333-000

--- a/releases/fbc/4-19/stage/submariner-fbc-4-19-stage-20260304-01.yaml
+++ b/releases/fbc/4-19/stage/submariner-fbc-4-19-stage-20260304-01.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-19-stage-20260304-01
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-stage-4-19
+  snapshot: submariner-fbc-4-19-20260303-205333-000

--- a/releases/fbc/4-20/stage/submariner-fbc-4-20-stage-20260304-01.yaml
+++ b/releases/fbc/4-20/stage/submariner-fbc-4-20-stage-20260304-01.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-20-stage-20260304-01
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-stage-4-20
+  snapshot: submariner-fbc-4-20-20260303-205332-000

--- a/releases/fbc/4-21/stage/submariner-fbc-4-21-stage-20260304-01.yaml
+++ b/releases/fbc/4-21/stage/submariner-fbc-4-21-stage-20260304-01.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-21-stage-20260304-01
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-stage-4-21
+  snapshot: submariner-fbc-4-21-20260303-205332-000


### PR DESCRIPTION
Generated 6 Release CRs (OCP 4-16 through 4-21) with:
- Verified GitHub catalog consistency
- Verified FBC snapshots (push events, tests passed)
- Verified component SHAs across all sources
- Validated with make test-remote