### PR TITLE
Add create-component-release skill

### DIFF
--- a/.claude/SKILLS.md
+++ b/.claude/SKILLS.md
@@ -213,6 +213,51 @@ make create-fbc-releases VERSION=0.22.1 TYPE=prod    # Production
 
 **To undo:** `git reset HEAD~1`
 
+## /create-component-release
+
+Create component release (stage or prod) with comprehensive verification
+
+Automates Step 8 (stage) and Step 15 (prod) of the Submariner release workflow.
+
+```bash
+/create-component-release 0.22.1          # Stage (default)
+/create-component-release 0.22.1 stage    # Stage (explicit)
+/create-component-release 0.22.1 prod     # Prod (copies stage)
+/create-component-release 0.22            # Auto-expands to 0.22.0
+```
+
+**Alternative (make target):**
+
+```bash
+make create-component-release VERSION=0.22.1              # Stage (default)
+make create-component-release VERSION=0.22.1 TYPE=prod    # Production
+```
+
+**Prerequisites:**
+
+- oc login (required for snapshot queries)
+- **For stage:** Step 7 complete (bundle SHAs updated)
+- **For prod:** Stage YAML exists with release notes (Steps 8-9 complete)
+
+**What it does:**
+
+1. Verifies latest component snapshot (push event, tests passed, 9 components)
+2. Generates Release YAML (stage or prod mode)
+3. Validates with make test-remote
+4. Commits automatically
+
+**After running:**
+
+- **Stage:** Fill notes placeholder via Step 9 workflow, then apply
+- **Prod:** Apply immediately (notes copied from stage)
+
+1. Review commit: `git show`
+2. Push: `git push origin $(git rev-parse --abbrev-ref HEAD)`
+3. Apply: `make apply FILE=<yaml>`
+4. Monitor: `make watch NAME=<release-name>`
+
+**To undo:** `git reset HEAD~1`
+
 ## Installation
 
 ### .claude/settings.json

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test test-remote validate-yaml validate-fields validate-data validate-references validate-bundle-images validate-markdown gitlint shellcheck apply watch create-fbc-releases
+.PHONY: help test test-remote validate-yaml validate-fields validate-data validate-references validate-bundle-images validate-markdown gitlint shellcheck apply watch create-fbc-releases create-component-release
 
 .DEFAULT_GOAL := help
 
@@ -15,6 +15,11 @@ help:
 	@echo "                           Default TYPE is stage if not specified"
 	@echo "                           Example: make create-fbc-releases VERSION=0.22.1"
 	@echo "                           Example: make create-fbc-releases VERSION=0.22.1 TYPE=prod"
+	@echo "  make create-component-release VERSION=... [TYPE=stage|prod]"
+	@echo "                         - Create component release (requires oc login)"
+	@echo "                           Default TYPE is stage if not specified"
+	@echo "                           Example: make create-component-release VERSION=0.22.1"
+	@echo "                           Example: make create-component-release VERSION=0.22.1 TYPE=prod"
 	@echo ""
 	@echo "Validation:"
 	@echo "  make test              - Run local validations (no cluster access needed)"
@@ -33,6 +38,10 @@ help:
 create-fbc-releases:
 	@test -n "$(VERSION)" || (echo "ERROR: VERSION parameter required. Usage: make create-fbc-releases VERSION=0.22.1 [TYPE=stage|prod]" && exit 1)
 	./scripts/create-fbc-releases.sh $(VERSION) $(if $(TYPE),--$(TYPE),--stage)
+
+create-component-release:
+	@test -n "$(VERSION)" || (echo "ERROR: VERSION parameter required. Usage: make create-component-release VERSION=0.22.1 [TYPE=stage|prod]" && exit 1)
+	./scripts/create-component-release.sh $(VERSION) $(if $(TYPE),$(TYPE),stage)
 
 test: validate-yaml validate-fields validate-data validate-markdown gitlint shellcheck
 

--- a/scripts/create-component-release.sh
+++ b/scripts/create-component-release.sh
@@ -1,0 +1,411 @@
+#!/bin/bash
+# Create component release (stage or prod)
+#
+# Usage: create-component-release.sh <version> [stage|prod]
+#
+# Arguments:
+#   version: Submariner version (e.g., 0.22.1 or 0.22)
+#   [stage|prod]: Release type (default: stage)
+#
+# Exit codes:
+#   0: Success (release created and committed)
+#   1: Failure (prerequisites, validation, or commit failed)
+
+set -euo pipefail
+
+# Global variables (set by parse_arguments)
+VERSION=""
+RELEASE_TYPE="stage"
+GIT_ROOT=""
+SCRIPTS_DIR=""
+
+# Global variables (set by verify_release)
+SNAPSHOT_NAME=""
+
+# Global variables (set by generate_yaml)
+YAML_FILE=""
+
+# ============================================================================
+# Prerequisites Check
+# ============================================================================
+
+check_prerequisites() {
+  local MISSING_TOOLS=()
+
+  command -v oc &>/dev/null || MISSING_TOOLS+=("oc")
+  command -v jq &>/dev/null || MISSING_TOOLS+=("jq")
+  command -v git &>/dev/null || MISSING_TOOLS+=("git")
+
+  if [ "${#MISSING_TOOLS[@]}" -gt 0 ]; then
+    echo "❌ ERROR: Missing required tools: ${MISSING_TOOLS[*]}"
+    echo ""
+    echo "Installation instructions:"
+    for tool in "${MISSING_TOOLS[@]}"; do
+      case "$tool" in
+        oc) echo "  oc: https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html" ;;
+        jq) echo "  jq: https://jqlang.github.io/jq/download/" ;;
+        git) echo "  git: https://git-scm.com/downloads" ;;
+      esac
+    done
+    exit 1
+  fi
+
+  # Check oc authentication (only for stage/prod that need snapshot)
+  if [ "$RELEASE_TYPE" = "stage" ]; then
+    if oc whoami &>/dev/null; then
+      :  # Already authenticated
+    else
+      echo ""
+      echo "============================================"
+      echo "ERROR: Not authenticated with Konflux"
+      echo "============================================"
+      echo "This script requires oc authentication."
+      echo "Run: oc login --web https://api.kflux-prd-rh02.0fk9.p1.openshiftapps.com:6443/"
+      echo ""
+      exit 1
+    fi
+  fi
+
+  echo "✓ Prerequisites verified: oc, jq, git"
+  if oc whoami &>/dev/null; then
+    echo "✓ Authenticated with Konflux as: $(oc whoami)"
+  fi
+}
+
+# ============================================================================
+# Argument Parsing
+# ============================================================================
+
+show_usage() {
+  echo "Usage: $0 <version> [stage|prod]"
+  echo "Example: $0 0.22.1"
+  echo "Example: $0 0.22.1 stage"
+  echo "Example: $0 0.22.1 prod"
+}
+
+parse_arguments() {
+  local VERSION_ARG="${1:-}"
+  local TYPE_ARG="${2:-}"
+
+  if [ -z "$VERSION_ARG" ]; then
+    echo "❌ ERROR: Version required"
+    show_usage
+    exit 1
+  fi
+
+  if [ $# -gt 2 ]; then
+    echo "❌ ERROR: Too many arguments"
+    show_usage
+    exit 1
+  fi
+
+  # Parse version
+  VERSION="$VERSION_ARG"
+
+  # Validate version format and expand if needed
+  if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
+    # X.Y format → default to X.Y.0
+    VERSION="${VERSION}.0"
+    echo "ℹ️  Defaulting to $VERSION (patch version 0)"
+  elif ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "❌ ERROR: Invalid version format: $VERSION"
+    echo "Expected: X.Y or X.Y.Z (e.g., 0.22 or 0.22.1)"
+    exit 1
+  fi
+
+  # Parse release type (default: stage)
+  if [ -n "$TYPE_ARG" ]; then
+    if [[ "$TYPE_ARG" = "stage" || "$TYPE_ARG" = "prod" ]]; then
+      RELEASE_TYPE="$TYPE_ARG"
+    else
+      echo "❌ ERROR: Invalid release type: $TYPE_ARG"
+      echo "Expected: stage or prod"
+      show_usage
+      exit 1
+    fi
+  fi
+
+  echo ""
+  echo "============================================"
+  echo "Component $RELEASE_TYPE Release Creation"
+  echo "============================================"
+  echo "Version: $VERSION"
+  echo "Release type: $RELEASE_TYPE"
+  if [ "$RELEASE_TYPE" = "stage" ]; then
+    echo "Release notes: Placeholder (fill via Step 9 workflow)"
+  else
+    echo "Release notes: Copied from stage"
+  fi
+  echo ""
+
+  # Find git repository root (allows running from anywhere in repo)
+  GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+  if [ -z "$GIT_ROOT" ]; then
+    echo "❌ ERROR: Not in a git repository"
+    exit 1
+  fi
+
+  # Set up paths relative to git root
+  SCRIPTS_DIR="$GIT_ROOT/scripts"
+
+  # Verify helper scripts exist
+  if [ ! -x "$SCRIPTS_DIR/verify-component-release.sh" ] || \
+     [ ! -x "$SCRIPTS_DIR/generate-component-release.sh" ]; then
+    echo "❌ ERROR: Required helper scripts not found"
+    echo "This script requires:"
+    echo "  - scripts/verify-component-release.sh"
+    echo "  - scripts/generate-component-release.sh"
+    exit 1
+  fi
+
+  echo "Repository root: $GIT_ROOT"
+  echo ""
+
+  # Check git status (working tree should be clean)
+  if git diff-index --quiet HEAD -- 2>/dev/null; then
+    :  # Working tree is clean
+  else
+    echo "⚠️  WARNING: Working tree has uncommitted changes"
+    echo "Proceeding anyway - you can review changes before pushing"
+    echo ""
+  fi
+}
+
+# ============================================================================
+# Verify Release Readiness
+# ============================================================================
+
+verify_release() {
+  # Skip verification for prod (uses same snapshot as stage)
+  if [ "$RELEASE_TYPE" = "prod" ]; then
+    echo "Skipping snapshot verification for prod release"
+    echo "(Prod uses same snapshot as stage - already verified)"
+    echo ""
+    # Extract snapshot from stage YAML for prod generation
+    local VERSION_MAJOR_MINOR
+    VERSION_MAJOR_MINOR=$(echo "$VERSION" | grep -oE '^[0-9]+\.[0-9]+')
+    local VERSION_FULL_DASH
+    VERSION_FULL_DASH="${VERSION//./-}"
+    local STAGE_DIR="releases/${VERSION_MAJOR_MINOR}/stage"
+    local STAGE_YAML
+    STAGE_YAML=$(find "$STAGE_DIR" -name "submariner-${VERSION_FULL_DASH}-stage-*.yaml" -type f | sort | tail -1)
+    if [ -z "$STAGE_YAML" ]; then
+      echo "❌ ERROR: No stage YAML found"
+      echo "Run stage creation first: $0 $VERSION stage"
+      exit 1
+    fi
+    SNAPSHOT_NAME=$(grep "snapshot:" "$STAGE_YAML" | awk '{print $2}')
+    echo "Using snapshot from stage: $SNAPSHOT_NAME"
+    echo ""
+    return 0
+  fi
+
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "Verifying component snapshot"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+
+  # Call verification script
+  local VERIFY_JSON
+  VERIFY_JSON=$("$SCRIPTS_DIR/verify-component-release.sh" "$VERSION" 2>&1)
+  local VERIFY_EXIT=$?
+
+  if [ $VERIFY_EXIT -ne 0 ]; then
+    echo "$VERIFY_JSON"
+    echo ""
+    echo "❌ Verification failed"
+    exit 1
+  fi
+
+  # Extract JSON (last line) and diagnostic output (everything else)
+  local VERIFY_RESULT
+  VERIFY_RESULT=$(echo "$VERIFY_JSON" | tail -1)
+
+  # Show diagnostic output from script
+  echo "$VERIFY_JSON" | head -n -1
+
+  # Parse JSON to verify status
+  local STATUS
+  STATUS=$(echo "$VERIFY_RESULT" | jq -r '.status' 2>/dev/null || echo "invalid")
+  if [ "$STATUS" != "pass" ]; then
+    echo "❌ Verification failed (invalid JSON output)"
+    exit 1
+  fi
+
+  # Extract snapshot name
+  SNAPSHOT_NAME=$(echo "$VERIFY_RESULT" | jq -r '.snapshot')
+
+  echo ""
+}
+
+# ============================================================================
+# Generate Release YAML
+# ============================================================================
+
+generate_yaml() {
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "Generating Release YAML"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+
+  # Get release date
+  local RELEASE_DATE
+  RELEASE_DATE=$(date +%Y%m%d)
+
+  # Change to git root so generate script can use relative paths
+  cd "$GIT_ROOT" || exit 1
+
+  # Call generate script
+  YAML_FILE=$("$SCRIPTS_DIR/generate-component-release.sh" "$VERSION" "$SNAPSHOT_NAME" "$RELEASE_TYPE" "$RELEASE_DATE" 2>&1)
+  local GENERATE_EXIT=$?
+
+  if [ $GENERATE_EXIT -ne 0 ]; then
+    echo "$YAML_FILE"
+    echo "❌ Failed to generate YAML"
+    exit 1
+  fi
+
+  # Extract filename from output (last line should be the file path)
+  YAML_FILE=$(echo "$YAML_FILE" | tail -1)
+
+  if [ ! -f "$YAML_FILE" ]; then
+    echo "❌ Generated file not found: $YAML_FILE"
+    exit 1
+  fi
+
+  echo "✓ Created: $YAML_FILE"
+  echo ""
+}
+
+# ============================================================================
+# Validate YAML
+# ============================================================================
+
+validate_yaml() {
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "Validating Release YAML"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+
+  echo "Validating $(basename "$YAML_FILE")..."
+
+  if [ "$RELEASE_TYPE" = "prod" ]; then
+    # For prod, run local validation only (snapshot not releasable yet)
+    echo "Running local validation only (prod uses same snapshot as stage)..."
+    if make -C "$GIT_ROOT" test FILE="$YAML_FILE" >/dev/null 2>&1; then
+      echo "  ✓ Validation passed"
+    else
+      echo "  ✗ Validation failed"
+      echo ""
+      echo "❌ Validation failed"
+      echo "Run 'make -C $GIT_ROOT test FILE=$YAML_FILE' for details"
+      exit 1
+    fi
+  else
+    # For stage with notes placeholder, run full validation
+    echo "Running full validation (including cluster checks)..."
+    if make -C "$GIT_ROOT" test-remote FILE="$YAML_FILE" >/dev/null 2>&1; then
+      echo "  ✓ Validation passed"
+    else
+      echo "  ✗ Validation failed"
+      echo ""
+      echo "❌ Validation failed"
+      echo "Run 'make -C $GIT_ROOT test-remote FILE=$YAML_FILE' for details"
+      exit 1
+    fi
+  fi
+
+  echo ""
+  echo "✓ YAML validation passed"
+}
+
+# ============================================================================
+# Commit Changes
+# ============================================================================
+
+commit_changes() {
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "Creating commit"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+
+  # Stage the created file
+  git add "$YAML_FILE" || {
+    echo "❌ ERROR: Failed to stage file"
+    exit 1
+  }
+
+  # Show what's being committed
+  echo "File to commit:"
+  git status --short | grep "^A" | sed 's/^A  /  /'
+  echo ""
+
+  # Create commit message
+  local COMMIT_MSG
+  if [ "$RELEASE_TYPE" = "stage" ]; then
+    COMMIT_MSG="Add component ${RELEASE_TYPE} release for $VERSION
+
+Snapshot: $SNAPSHOT_NAME
+Release notes: Fill placeholder via Step 9 workflow"
+  else
+    COMMIT_MSG="Add component ${RELEASE_TYPE} release for $VERSION
+
+Snapshot: $SNAPSHOT_NAME (same as stage)
+Release notes: Copied from stage (QE-verified)"
+  fi
+
+  # Create commit
+  git commit -s -m "$COMMIT_MSG" || {
+    echo "❌ ERROR: Failed to create commit"
+    exit 1
+  }
+
+  local COMMIT_HASH
+  COMMIT_HASH=$(git rev-parse --short HEAD)
+
+  echo "✓ Commit created: $COMMIT_HASH"
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "SUCCESS - Component ${RELEASE_TYPE} release created"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+  echo "Next steps:"
+  echo ""
+  echo "1. Review changes:"
+  echo "   git show"
+  echo ""
+  echo "2. Push commit:"
+  echo "   git push origin \$(git rev-parse --abbrev-ref HEAD)"
+  echo ""
+  if [ "$RELEASE_TYPE" = "stage" ]; then
+    echo "3. Fill release notes placeholder (issues.fixed[], cves[])"
+    echo ""
+    echo "4. Apply release to cluster:"
+  else
+    echo "3. Apply release to cluster:"
+  fi
+  echo "   make apply FILE=$YAML_FILE"
+  local RELEASE_NAME
+  RELEASE_NAME=$(basename "$YAML_FILE" .yaml)
+  echo "   make watch NAME=$RELEASE_NAME"
+  echo ""
+  echo "To undo this commit:"
+  echo "   git reset HEAD~1"
+  echo ""
+}
+
+# ============================================================================
+# Main Execution
+# ============================================================================
+
+main() {
+  check_prerequisites
+  parse_arguments "$@"
+  verify_release
+  generate_yaml
+  validate_yaml
+  commit_changes
+}
+
+main "$@"

--- a/scripts/generate-component-release.sh
+++ b/scripts/generate-component-release.sh
@@ -1,0 +1,210 @@
+#!/bin/bash
+# Generate single component Release YAML
+#
+# Usage: generate-component-release.sh <version> <snapshot> <release-type> <release-date>
+#
+# Arguments:
+#   version:       Submariner version (e.g., 0.22.1)
+#   snapshot:      Snapshot name (e.g., submariner-0-22-xxxxx)
+#   release-type:  stage or prod
+#   release-date:  Release date in YYYYMMDD format
+#
+# Output: Path to created YAML file (stdout)
+# Exit codes:
+#   0: Success
+#   1: Failure (invalid arguments, directory creation failed, write failed)
+
+set -euo pipefail
+
+# ============================================================================
+# Argument Parsing
+# ============================================================================
+
+if [ $# -ne 4 ]; then
+  echo "❌ ERROR: Invalid number of arguments" >&2
+  echo "Usage: $0 <version> <snapshot> <release-type> <release-date>" >&2
+  echo "Example: $0 0.22.1 submariner-0-22-abc123 stage 20260312" >&2
+  exit 1
+fi
+
+VERSION="$1"
+SNAPSHOT="$2"
+RELEASE_TYPE="$3"
+RELEASE_DATE="$4"
+
+# ============================================================================
+# Validation
+# ============================================================================
+
+# Validate version format (X.Y.Z)
+if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  :  # Version format is valid
+else
+  echo "❌ ERROR: Invalid version format: $VERSION" >&2
+  echo "Expected: X.Y.Z (e.g., 0.22.1)" >&2
+  echo "Note: This script requires full version including patch" >&2
+  exit 1
+fi
+
+# Extract major.minor for directory structure
+VERSION_MAJOR_MINOR=$(echo "$VERSION" | grep -oE '^[0-9]+\.[0-9]+')
+VERSION_MAJOR_MINOR_DASH="${VERSION_MAJOR_MINOR//./-}"  # 0.22 → 0-22
+
+# Version with dashes for naming (0.22.1 → 0-22-1)
+VERSION_DASH="${VERSION//./-}"
+
+# Validate release type
+if [[ "$RELEASE_TYPE" != "stage" && "$RELEASE_TYPE" != "prod" ]]; then
+  echo "❌ ERROR: Invalid release type: $RELEASE_TYPE" >&2
+  echo "Expected: stage or prod" >&2
+  exit 1
+fi
+
+# Validate release date format (YYYYMMDD)
+if [[ "$RELEASE_DATE" =~ ^[0-9]{8}$ ]]; then
+  :  # Release date format is valid
+else
+  echo "❌ ERROR: Invalid release date format: $RELEASE_DATE" >&2
+  echo "Expected: YYYYMMDD (e.g., 20260312)" >&2
+  exit 1
+fi
+
+# Validate snapshot name format
+if [[ "$SNAPSHOT" =~ ^submariner-${VERSION_MAJOR_MINOR_DASH}- ]]; then
+  :  # Snapshot name format is valid
+else
+  echo "❌ ERROR: Snapshot name doesn't match version" >&2
+  echo "Expected: submariner-${VERSION_MAJOR_MINOR_DASH}-..." >&2
+  echo "Got: $SNAPSHOT" >&2
+  exit 1
+fi
+
+# ============================================================================
+# Production Mode: Copy from Stage
+# ============================================================================
+
+if [ "$RELEASE_TYPE" = "prod" ]; then
+  # Find stage YAML to copy from
+  STAGE_DIR="releases/${VERSION_MAJOR_MINOR}/stage"
+
+  if [ ! -d "$STAGE_DIR" ]; then
+    echo "❌ ERROR: Stage directory not found: $STAGE_DIR" >&2
+    echo "Run stage creation first: create-component-release.sh $VERSION ... stage ..." >&2
+    exit 1
+  fi
+
+  # Find latest stage YAML for this version
+  STAGE_YAML=$(find "$STAGE_DIR" -name "submariner-${VERSION_DASH}-stage-*.yaml" -type f | sort | tail -1)
+
+  if [ -z "$STAGE_YAML" ] || [ ! -f "$STAGE_YAML" ]; then
+    echo "❌ ERROR: No stage YAML found for version $VERSION" >&2
+    echo "Expected: $STAGE_DIR/submariner-${VERSION_DASH}-stage-*.yaml" >&2
+    echo "Run stage creation first" >&2
+    exit 1
+  fi
+
+  echo "Reading stage YAML: $STAGE_YAML" >&2
+
+  # Create prod directory
+  PROD_DIR="releases/${VERSION_MAJOR_MINOR}/prod"
+  mkdir -p "$PROD_DIR" || {
+    echo "❌ ERROR: Failed to create directory: $PROD_DIR" >&2
+    exit 1
+  }
+
+  # Determine sequence number for prod
+  SEQUENCE=1
+  while [ -f "${PROD_DIR}/submariner-${VERSION_DASH}-prod-${RELEASE_DATE}-$(printf '%02d' $SEQUENCE).yaml" ]; do
+    ((SEQUENCE++))
+  done
+
+  PROD_FILENAME="submariner-${VERSION_DASH}-prod-${RELEASE_DATE}-$(printf '%02d' $SEQUENCE).yaml"
+  PROD_FILE="${PROD_DIR}/${PROD_FILENAME}"
+
+  # Copy stage YAML and modify
+  # Change metadata.name: stage → prod, update date
+  # Change spec.releasePlan: stage-0-X → prod-0-X
+  # Keep spec.snapshot and spec.data.releaseNotes identical
+
+  sed -e "s/name: submariner-${VERSION_DASH}-stage-[0-9]\{8\}-[0-9]\{2\}/name: submariner-${VERSION_DASH}-prod-${RELEASE_DATE}-$(printf '%02d' $SEQUENCE)/" \
+      -e "s/releasePlan: submariner-release-plan-stage-${VERSION_MAJOR_MINOR_DASH}/releasePlan: submariner-release-plan-prod-${VERSION_MAJOR_MINOR_DASH}/" \
+      "$STAGE_YAML" > "$PROD_FILE"
+
+  if [ ! -f "$PROD_FILE" ]; then
+    echo "❌ ERROR: Failed to create prod YAML: $PROD_FILE" >&2
+    exit 1
+  fi
+
+  # Verify file has expected content
+  if ! grep -q "snapshot: ${SNAPSHOT}" "$PROD_FILE"; then
+    echo "❌ ERROR: Prod YAML missing expected snapshot: $SNAPSHOT" >&2
+    echo "Check that stage YAML uses the same snapshot" >&2
+    exit 1
+  fi
+
+  if ! grep -q "releasePlan: submariner-release-plan-prod-${VERSION_MAJOR_MINOR_DASH}" "$PROD_FILE"; then
+    echo "❌ ERROR: Prod YAML has incorrect releasePlan" >&2
+    exit 1
+  fi
+
+  echo "✓ Created prod YAML: $PROD_FILE" >&2
+  echo "$PROD_FILE"
+  exit 0
+fi
+
+# ============================================================================
+# Stage Mode: Generate YAML
+# ============================================================================
+
+# Create stage directory
+STAGE_DIR="releases/${VERSION_MAJOR_MINOR}/stage"
+mkdir -p "$STAGE_DIR" || {
+  echo "❌ ERROR: Failed to create directory: $STAGE_DIR" >&2
+  exit 1
+}
+
+# Determine sequence number (support retries)
+SEQUENCE=1
+while [ -f "${STAGE_DIR}/submariner-${VERSION_DASH}-stage-${RELEASE_DATE}-$(printf '%02d' $SEQUENCE).yaml" ]; do
+  ((SEQUENCE++))
+done
+
+# Generate filename
+STAGE_FILENAME="submariner-${VERSION_DASH}-stage-${RELEASE_DATE}-$(printf '%02d' $SEQUENCE).yaml"
+STAGE_FILE="${STAGE_DIR}/${STAGE_FILENAME}"
+
+# Generate YAML with release notes placeholder (user fills via Step 9 workflow)
+cat > "$STAGE_FILE" <<EOF
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-${VERSION_DASH}-stage-${RELEASE_DATE}-$(printf '%02d' $SEQUENCE)
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-release-plan-stage-${VERSION_MAJOR_MINOR_DASH}
+  snapshot: ${SNAPSHOT}
+  data:
+    releaseNotes:
+      type: RHBA  # Change to RHSA if adding CVEs, RHEA for enhancements
+      issues:
+        fixed: []  # Fill with Step 9 workflow
+      cves: []     # Fill with Step 9 workflow (required if type=RHSA)
+EOF
+
+# Verify file was created
+if [ ! -f "$STAGE_FILE" ]; then
+  echo "❌ ERROR: Failed to create YAML file: $STAGE_FILE" >&2
+  exit 1
+fi
+
+# Verify file has expected content
+if ! grep -q "snapshot: ${SNAPSHOT}" "$STAGE_FILE"; then
+  echo "❌ ERROR: YAML file missing expected content" >&2
+  exit 1
+fi
+
+# Output the file path to stdout
+echo "$STAGE_FILE"

--- a/scripts/verify-component-release.sh
+++ b/scripts/verify-component-release.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+# Verify component release readiness
+#
+# Usage: verify-component-release.sh <version>
+#
+# Arguments:
+#   version: Submariner version (e.g., 0.22.1 or 0.22)
+#
+# Output:
+#   stderr: Diagnostic output (✓/✗ messages)
+#   stdout: JSON result {"status": "pass|fail", "snapshot": "name"}
+#
+# Exit codes:
+#   0: Success (verification passed)
+#   1: Failure (no snapshot found or verification failed)
+
+set -euo pipefail
+
+# ============================================================================
+# Argument Parsing and Version Detection
+# ============================================================================
+
+if [ $# -ne 1 ]; then
+  echo "❌ ERROR: Invalid number of arguments" >&2
+  echo "Usage: $0 <version>" >&2
+  echo "Example: $0 0.22.1" >&2
+  exit 1
+fi
+
+VERSION="$1"
+
+# Validate version format (X.Y or X.Y.Z)
+if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+  :  # Version format is valid
+else
+  echo "❌ ERROR: Invalid version format: $VERSION" >&2
+  echo "Expected: X.Y or X.Y.Z (e.g., 0.22 or 0.22.1)" >&2
+  exit 1
+fi
+
+# Extract major.minor version for snapshot filtering
+# 0.22.1 → 0.22, 0.22 → 0.22
+VERSION_MAJOR_MINOR=$(echo "$VERSION" | grep -oE '^[0-9]+\.[0-9]+')
+VERSION_MAJOR_MINOR_DASH="${VERSION_MAJOR_MINOR//./-}"  # 0.22 → 0-22
+
+echo "=== Verifying Component Release Readiness ===" >&2
+echo "" >&2
+echo "Version: $VERSION_MAJOR_MINOR (searching for submariner-${VERSION_MAJOR_MINOR_DASH}- snapshots)" >&2
+echo "" >&2
+
+# ============================================================================
+# Find Latest Component Snapshot
+# ============================================================================
+
+echo "Querying Konflux for component snapshots..." >&2
+
+# Batched query (1 API call instead of many)
+ALL_SNAPSHOTS=$(oc get snapshots -n submariner-tenant -o json 2>/dev/null)
+
+if [ -z "$ALL_SNAPSHOTS" ]; then
+  echo "❌ ERROR: Failed to query snapshots from cluster" >&2
+  echo "Check: oc login status and network connectivity" >&2
+  exit 1
+fi
+
+# Filter to component snapshots for this version
+# - Name matches: submariner-0-X-*
+# - Event type: push (not PR builds)
+# - Sort by creation timestamp, take latest
+SNAPSHOT_NAME=$(echo "$ALL_SNAPSHOTS" | jq -r "
+  .items[]
+  | select(.metadata.name | startswith(\"submariner-${VERSION_MAJOR_MINOR_DASH}-\"))
+  | select(.metadata.labels.\"pac.test.appstudio.openshift.io/event-type\" == \"push\")
+  | {name: .metadata.name, created: .metadata.creationTimestamp}
+" | jq -rs 'sort_by(.created) | reverse | .[0].name' 2>/dev/null)
+
+if [ -z "$SNAPSHOT_NAME" ] || [ "$SNAPSHOT_NAME" = "null" ]; then
+  echo "❌ ERROR: No passing component snapshot found for version $VERSION_MAJOR_MINOR" >&2
+  echo "" >&2
+  echo "Possible causes:" >&2
+  echo "- Step 7 not complete (bundle not built)" >&2
+  echo "- Latest snapshot is from PR (not push event)" >&2
+  echo "- Check: oc get snapshots -n submariner-tenant | grep submariner-${VERSION_MAJOR_MINOR_DASH}" >&2
+  exit 1
+fi
+
+# Extract creation timestamp for display
+SNAPSHOT_CREATED=$(echo "$ALL_SNAPSHOTS" | jq -r "
+  .items[] | select(.metadata.name == \"$SNAPSHOT_NAME\") | .metadata.creationTimestamp
+")
+
+echo "✓ Found snapshot: $SNAPSHOT_NAME (created $SNAPSHOT_CREATED)" >&2
+
+# ============================================================================
+# Verify 9 Components Present
+# ============================================================================
+
+echo "" >&2
+echo "Verifying snapshot has all 9 components..." >&2
+
+# Expected components (must all be present)
+EXPECTED_COMPONENTS=(
+  "submariner-operator-${VERSION_MAJOR_MINOR_DASH}"
+  "submariner-gateway-${VERSION_MAJOR_MINOR_DASH}"
+  "submariner-globalnet-${VERSION_MAJOR_MINOR_DASH}"
+  "submariner-route-agent-${VERSION_MAJOR_MINOR_DASH}"
+  "lighthouse-agent-${VERSION_MAJOR_MINOR_DASH}"
+  "lighthouse-coredns-${VERSION_MAJOR_MINOR_DASH}"
+  "nettest-${VERSION_MAJOR_MINOR_DASH}"
+  "subctl-${VERSION_MAJOR_MINOR_DASH}"
+  "submariner-bundle-${VERSION_MAJOR_MINOR_DASH}"
+)
+
+# Extract actual components from snapshot
+ACTUAL_COMPONENTS=$(echo "$ALL_SNAPSHOTS" | jq -r "
+  .items[] | select(.metadata.name == \"$SNAPSHOT_NAME\") | .spec.components[].name
+" | sort)
+
+MISSING_COMPONENTS=()
+for EXPECTED in "${EXPECTED_COMPONENTS[@]}"; do
+  if echo "$ACTUAL_COMPONENTS" | grep -qx "$EXPECTED"; then
+    echo "  ✓ $EXPECTED" >&2
+  else
+    echo "  ✗ $EXPECTED (MISSING)" >&2
+    MISSING_COMPONENTS+=("$EXPECTED")
+  fi
+done
+
+if [ ${#MISSING_COMPONENTS[@]} -gt 0 ]; then
+  echo "" >&2
+  echo "❌ ERROR: Snapshot missing ${#MISSING_COMPONENTS[@]} component(s)" >&2
+  echo "Expected 9 components, found $((9 - ${#MISSING_COMPONENTS[@]}))" >&2
+  echo "Missing: ${MISSING_COMPONENTS[*]}" >&2
+  exit 1
+fi
+
+echo "✓ All 9 components present in snapshot" >&2
+
+# ============================================================================
+# Verify All Tests Passed
+# ============================================================================
+
+echo "" >&2
+echo "Verifying all tests passed..." >&2
+
+# Extract test status annotation
+TEST_STATUS=$(echo "$ALL_SNAPSHOTS" | jq -r "
+  .items[] | select(.metadata.name == \"$SNAPSHOT_NAME\")
+  | .metadata.annotations.\"test.appstudio.openshift.io/status\"
+" 2>/dev/null)
+
+if [ -z "$TEST_STATUS" ] || [ "$TEST_STATUS" = "null" ]; then
+  echo "⚠️  WARNING: No test status annotation found" >&2
+  echo "Snapshot may not have completed testing yet" >&2
+  echo "Check: oc get snapshot $SNAPSHOT_NAME -n submariner-tenant -o jsonpath='{.metadata.annotations}'" >&2
+  # Don't fail - some snapshots may not have tests yet
+  TEST_STATUS="[]"
+fi
+
+# Parse test status JSON
+FAILED_TESTS=$(echo "$TEST_STATUS" | jq -r '.[] | select(.status != "TestPassed") | .scenario' 2>/dev/null)
+
+if [ -n "$FAILED_TESTS" ]; then
+  echo "❌ ERROR: Snapshot has failing tests" >&2
+  echo "" >&2
+  echo "Failed test scenarios:" >&2
+  echo "$FAILED_TESTS" | while read -r scenario; do
+    echo "  - $scenario" >&2
+  done
+  echo "" >&2
+  echo "All tests must pass before creating a release" >&2
+  exit 1
+fi
+
+# Check for enterprise-contract specifically (critical for releases)
+EC_TEST=$(echo "$TEST_STATUS" | jq -r '.[] | select(.scenario | contains("enterprise-contract")) | .status' 2>/dev/null)
+
+if [ -n "$EC_TEST" ]; then
+  if [ "$EC_TEST" = "TestPassed" ]; then
+    echo "  ✓ enterprise-contract: TestPassed" >&2
+  else
+    echo "  ✗ enterprise-contract: $EC_TEST (CRITICAL FAILURE)" >&2
+    exit 1
+  fi
+fi
+
+# Count total tests
+TOTAL_TESTS=$(echo "$TEST_STATUS" | jq -r '. | length' 2>/dev/null)
+if [ "$TOTAL_TESTS" -gt 0 ]; then
+  echo "✓ All $TOTAL_TESTS test(s) passed" >&2
+else
+  echo "⚠️  No tests found in snapshot (may still be building)" >&2
+fi
+
+# ============================================================================
+# Output JSON Result
+# ============================================================================
+
+echo "" >&2
+echo "✅ Verification complete - snapshot ready for release" >&2
+echo "" >&2
+
+# Output JSON to stdout (orchestrator parses this)
+jq -nc \
+  --arg status "pass" \
+  --arg snapshot "$SNAPSHOT_NAME" \
+  '{status: $status, snapshot: $snapshot}'

--- a/skills/create-component-release/SKILL.md
+++ b/skills/create-component-release/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: create-component-release
+description: Create component release (stage or prod) with comprehensive verification
+version: 2.0.0
+argument-hint: "<version> [stage|prod]"
+user-invocable: true
+allowed-tools: Bash
+---
+
+# Create Component Release
+
+Automates Step 8 (stage), and Step 15 (prod) of the Submariner release workflow.
+
+**What it does:**
+
+- Verifies latest component snapshot (event type, tests, 9 components)
+- Generates 1 Release YAML (stage or prod)
+- Validates YAML with make test-remote
+- Automatically commits with descriptive message
+
+**Usage:**
+
+```bash
+/create-component-release 0.22.1          # Stage (default)
+/create-component-release 0.22.1 stage    # Stage (explicit)
+/create-component-release 0.22.1 prod     # Prod (copies stage notes)
+/create-component-release 0.22            # Auto-expands to 0.22.0
+```
+
+**Prerequisites:**
+
+- oc login (required for snapshot queries)
+- **For stage:** Step 7 complete (bundle SHAs updated)
+- **For prod:** Stage YAML exists with release notes (Steps 8-9 complete)
+
+**Arguments:** $ARGUMENTS
+
+---
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# Find git repository root
+GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$GIT_ROOT" ]; then
+  echo "❌ ERROR: Not in a git repository"
+  exit 1
+fi
+
+# Verify orchestrator script exists
+if [ ! -x "$GIT_ROOT/scripts/create-component-release.sh" ]; then
+  echo "❌ ERROR: Required orchestrator script not found"
+  echo "This skill requires: scripts/create-component-release.sh"
+  exit 1
+fi
+
+# Delegate to orchestrator (passes all arguments)
+exec "$GIT_ROOT/scripts/create-component-release.sh" $ARGUMENTS
+```


### PR DESCRIPTION
Automates Step 8 (stage) and Step 15 (prod) of Submariner release workflow with verification, validation, and auto-commit.

Usage:
  /create-component-release 0.22.1          # stage (default)
  /create-component-release 0.22.1 prod     # prod
  make create-component-release VERSION=0.22.1 TYPE=prod