### PR TITLE
Add rpm-lockfile-update skill

### DIFF
--- a/.agents/workflows/scan-cves.md
+++ b/.agents/workflows/scan-cves.md
@@ -18,7 +18,13 @@ Run CVE workflow (from each repo's CLAUDE.md on devel) on release-0.X branch for
 
 ### RPM Dependencies
 
-**TODO:** Update RPM lockfiles to fix RPM package CVEs.
+Update RPM lockfiles to fix RPM package CVEs:
+
+```bash
+/rpm-lockfile-update <branch>
+```
+
+This updates lockfiles in submariner (3 components) and shipyard (1 component) repos.
 
 ### Addon Go Toolchain
 

--- a/.claude/SKILLS.md
+++ b/.claude/SKILLS.md
@@ -133,6 +133,27 @@ regenerates bundle manifests, and verifies all SHAs match.
 
 **After running:** Review commit, push to remote, wait for bundle rebuild (~15-30 min)
 
+## /rpm-lockfile-update
+
+Regenerates RPM lockfiles in submariner and shipyard repositories by creating fix branches, running hermetic builds,
+and committing updated lockfiles.
+
+```bash
+/rpm-lockfile-update                             # Auto-detect branch, all repos
+/rpm-lockfile-update 0.21                        # Explicit branch, all repos
+/rpm-lockfile-update gateway                     # Auto-detect branch, gateway only
+/rpm-lockfile-update 0.21 submariner             # Explicit branch, repo filter
+make rpm-lockfile-update                         # Auto-detect branch
+make rpm-lockfile-update COMPONENT=gateway       # Auto-detect, component filter
+make rpm-lockfile-update BRANCH=0.21 COMPONENT=gateway  # Explicit branch
+```
+
+**Filter options:** all, submariner, shipyard, gateway, globalnet, route-agent, nettest
+
+**Requirements:** Red Hat entitlements, `podman login registry.redhat.io`, `gh auth login`, Bash 4.0+
+
+**After running:** Review commits, push to remote, create PRs per repo
+
 ## /konflux-bundle-setup
 
 Automate Konflux bundle setup on new release branches

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test test-remote validate-yaml validate-fields validate-data validate-references validate-bundle-images validate-markdown gitlint shellcheck apply watch create-fbc-releases create-component-release
+.PHONY: help test test-remote validate-yaml validate-fields validate-data validate-references validate-bundle-images validate-markdown gitlint shellcheck apply watch create-fbc-releases create-component-release rpm-lockfile-update
 
 .DEFAULT_GOAL := help
 
@@ -20,6 +20,11 @@ help:
 	@echo "                           Default TYPE is stage if not specified"
 	@echo "                           Example: make create-component-release VERSION=0.22.1"
 	@echo "                           Example: make create-component-release VERSION=0.22.1 TYPE=prod"
+	@echo "  make rpm-lockfile-update [BRANCH=...] [REPO=...|COMPONENT=...]"
+	@echo "                         - Update RPM lockfiles across Submariner repos"
+	@echo "                           Example: make rpm-lockfile-update"
+	@echo "                           Example: make rpm-lockfile-update COMPONENT=gateway"
+	@echo "                           Example: make rpm-lockfile-update BRANCH=0.21 COMPONENT=gateway"
 	@echo ""
 	@echo "Validation:"
 	@echo "  make test              - Run local validations (no cluster access needed)"
@@ -42,6 +47,9 @@ create-fbc-releases:
 create-component-release:
 	@test -n "$(VERSION)" || (echo "ERROR: VERSION parameter required. Usage: make create-component-release VERSION=0.22.1 [TYPE=stage|prod]" && exit 1)
 	./scripts/create-component-release.sh $(VERSION) $(if $(TYPE),$(TYPE),stage)
+
+rpm-lockfile-update:
+	./scripts/rpm-lockfile-update.sh $(BRANCH) $(if $(REPO),$(REPO),$(COMPONENT))
 
 test: validate-yaml validate-fields validate-data validate-markdown gitlint shellcheck
 

--- a/scripts/rpm-lockfile-update.sh
+++ b/scripts/rpm-lockfile-update.sh
@@ -1,0 +1,302 @@
+#!/bin/bash
+# Update RPM lockfiles across Submariner repositories
+#
+# Usage: rpm-lockfile-update.sh [branch] [repo|component]
+#
+# branch: Release branch (e.g., 0.21 or release-0.21), default: auto-detect
+# repo|component: submariner, shipyard, gateway, globalnet, route-agent, nettest, default: all
+
+set -euo pipefail
+
+# Constants
+readonly SUBMARINER_BASE="${HOME}/go/src/submariner-io"
+readonly COMPONENT_PATTERN="^(gateway|globalnet|route-agent|nettest)$"
+readonly FILTER_PATTERN="^(submariner|shipyard|gateway|globalnet|route-agent|nettest|all)$"
+readonly COMMIT_MSG="Regenerate RPM lockfiles for %s
+
+Updated lockfiles to resolve latest package versions."
+
+BRANCH=""
+VERSION=""
+COMPONENT_FILTER=""
+declare -a REPOS_UPDATED=()
+declare -a REPOS_SKIPPED=()
+declare -a REPOS_FAILED=()
+
+die() {
+  echo "❌ $1"
+  [ -n "${2:-}" ] && echo "$2"
+  exit 1
+}
+
+check_prerequisites() {
+  local MISSING_TOOLS=()
+
+  command -v git &>/dev/null || MISSING_TOOLS+=("git")
+  command -v podman &>/dev/null || MISSING_TOOLS+=("podman")
+  command -v gh &>/dev/null || MISSING_TOOLS+=("gh")
+
+  [ "${#MISSING_TOOLS[@]}" -gt 0 ] && die "Missing required tools: ${MISSING_TOOLS[*]}"
+
+  [ -z "${BASH_VERSINFO[0]}" ] || [ "${BASH_VERSINFO[0]}" -lt 4 ] && \
+    die "bash 4.0+ required" "macOS: brew install bash"
+
+  ls /etc/pki/entitlement/*.pem &>/dev/null || \
+    die "No Red Hat entitlements in /etc/pki/entitlement/" \
+        "Setup: https://github.com/submariner-io/shipyard/blob/devel/.rpm-lockfiles/README.md"
+
+  [ -s "${HOME}/.docker/config.json" ] || \
+    die "Not authenticated to registry" "Run: podman login registry.redhat.io"
+
+  gh auth status &>/dev/null || \
+    die "Not authenticated to GitHub" "Run: gh auth login"
+
+  echo "✓ Prerequisites verified"
+}
+
+parse_arguments() {
+  local ARG1="${1:-}"
+  local ARG2="${2:-}"
+  local BRANCH_ARG=""
+
+  [ $# -gt 2 ] && die "Too many arguments"
+
+  COMPONENT_FILTER="all"
+
+  if [ -n "$ARG1" ] && [ -z "$ARG2" ]; then
+    if [[ "$ARG1" =~ $FILTER_PATTERN ]]; then
+      COMPONENT_FILTER="$ARG1"
+    else
+      BRANCH_ARG="$ARG1"
+    fi
+  elif [ -n "$ARG2" ]; then
+    BRANCH_ARG="$ARG1"
+    [[ ! "$ARG2" =~ $FILTER_PATTERN ]] && \
+      die "Invalid repo/component: $ARG2" \
+          "Use: submariner, shipyard, gateway, globalnet, route-agent, nettest, or all"
+    COMPONENT_FILTER="$ARG2"
+  fi
+
+  # Normalize: 0.21 → release-0.21, or accept any branch
+  if [ -n "$BRANCH_ARG" ]; then
+    case "$BRANCH_ARG" in
+      release-*)
+        BRANCH="$BRANCH_ARG"
+        VERSION="${BRANCH#release-}"
+        ;;
+      [0-9].[0-9]*)
+        VERSION="$BRANCH_ARG"
+        BRANCH="release-${VERSION}"
+        ;;
+      *)
+        BRANCH="$BRANCH_ARG"
+        VERSION="$BRANCH_ARG"
+        ;;
+    esac
+  fi
+}
+
+cleanup_empty_branch() {
+  local branch="$1" branch_ref="$2" fix_branch="$3"
+
+  git show-ref --verify --quiet "refs/heads/$branch" && \
+    git checkout "$branch" >/dev/null 2>&1 || \
+    git checkout --detach "$branch_ref" >/dev/null 2>&1
+  git branch -D "$fix_branch" >/dev/null 2>&1 || true
+}
+
+update_lockfiles() {
+  local scope
+  case "$COMPONENT_FILTER" in
+    submariner|shipyard) scope="all components in $COMPONENT_FILTER" ;;
+    gateway|globalnet|route-agent|nettest) scope="$COMPONENT_FILTER component" ;;
+    *) scope="all components" ;;
+  esac
+
+  if [ -n "$BRANCH" ]; then
+    echo "Updating $scope on branch $BRANCH"
+  else
+    echo "Updating $scope on current branch (auto-detect per repo)"
+  fi
+  echo ""
+
+  local -a REPOS=()
+
+  case "$COMPONENT_FILTER" in
+    submariner|gateway|globalnet|route-agent)
+      REPOS+=("$SUBMARINER_BASE/submariner")
+      ;;
+    shipyard|nettest)
+      REPOS+=("$SUBMARINER_BASE/shipyard")
+      ;;
+    all)
+      REPOS+=("$SUBMARINER_BASE/submariner")
+      REPOS+=("$SUBMARINER_BASE/shipyard")
+      ;;
+  esac
+
+  local ORIGINAL_DIR
+  ORIGINAL_DIR=$(pwd)
+
+  for REPO_PATH in "${REPOS[@]}"; do
+    local REPO_NAME
+    REPO_NAME=$(basename "$REPO_PATH")
+    local DISPLAY_NAME="$REPO_NAME"
+    [[ "$COMPONENT_FILTER" =~ $COMPONENT_PATTERN ]] && DISPLAY_NAME="$COMPONENT_FILTER"
+
+    [ ! -d "$REPO_PATH" ] && { REPOS_SKIPPED+=("$DISPLAY_NAME:repo-not-found"); continue; }
+    cd "$REPO_PATH" || { REPOS_FAILED+=("$DISPLAY_NAME:cd-failed"); continue; }
+
+    # Auto-detect branch for this repo if not specified
+    local REPO_BRANCH="$BRANCH"
+    local REPO_VERSION="$VERSION"
+    if [ -z "$REPO_BRANCH" ]; then
+      REPO_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+      if [ -z "$REPO_BRANCH" ] || [ "$REPO_BRANCH" = "HEAD" ]; then
+        REPOS_SKIPPED+=("$DISPLAY_NAME:no-current-branch")
+        continue
+      fi
+      # Derive version from branch name
+      case "$REPO_BRANCH" in
+        release-*)
+          REPO_VERSION="${REPO_BRANCH#release-}"
+          ;;
+        *)
+          REPO_VERSION="$REPO_BRANCH"
+          ;;
+      esac
+    fi
+
+    [ "$DISPLAY_NAME" = "$REPO_NAME" ] && echo "==> $REPO_NAME" || echo "==> $DISPLAY_NAME (in $REPO_NAME)"
+    echo "    Branch: $REPO_BRANCH"
+
+    local BRANCH_REF="origin/$REPO_BRANCH"
+    git show-ref --verify --quiet "refs/remotes/$BRANCH_REF" || {
+      BRANCH_REF="$REPO_BRANCH"
+      git show-ref --verify --quiet "refs/heads/$BRANCH_REF" || {
+        REPOS_SKIPPED+=("$DISPLAY_NAME:branch-not-found")
+        continue
+      }
+    }
+
+    git ls-tree -r "$BRANCH_REF" -- .rpm-lockfiles/ 2>/dev/null | grep -q . || \
+      { REPOS_SKIPPED+=("$DISPLAY_NAME:no-lockfiles"); continue; }
+
+    local FIX_BRANCH="update-rpm-lockfiles-${REPO_VERSION}"
+
+    git checkout -B "$FIX_BRANCH" "$BRANCH_REF" >/dev/null 2>&1 || \
+      { REPOS_FAILED+=("$DISPLAY_NAME:branch-create-failed"); continue; }
+
+    git show "origin/devel:.rpm-lockfiles/update-lockfile.sh" > .rpm-lockfiles/update-lockfile.sh 2>/dev/null || {
+      echo "❌ Failed to copy update-lockfile.sh from origin/devel"
+      echo "   Run: git fetch origin devel"
+      REPOS_FAILED+=("$DISPLAY_NAME:script-copy-failed")
+      continue
+    }
+
+    chmod +x .rpm-lockfiles/update-lockfile.sh
+
+    set +e  # Disable errexit to capture exit code and cleanup
+    local LOCKFILE_PATTERN
+    if [[ "$COMPONENT_FILTER" =~ $COMPONENT_PATTERN ]]; then
+      LOCKFILE_PATTERN=".rpm-lockfiles/$COMPONENT_FILTER/rpms.lock.yaml"
+      echo "Running: .rpm-lockfiles/update-lockfile.sh $FIX_BRANCH $COMPONENT_FILTER"
+      echo ""
+      .rpm-lockfiles/update-lockfile.sh "$FIX_BRANCH" "$COMPONENT_FILTER"
+    else
+      LOCKFILE_PATTERN=".rpm-lockfiles/*/rpms.lock.yaml"
+      echo "Running: .rpm-lockfiles/update-lockfile.sh $FIX_BRANCH"
+      echo ""
+      .rpm-lockfiles/update-lockfile.sh "$FIX_BRANCH"
+    fi
+    local LOCKFILE_EXIT=$?
+    set -e
+    rm -f .rpm-lockfiles/update-lockfile.sh
+
+    if [ $LOCKFILE_EXIT -ne 0 ]; then
+      REPOS_FAILED+=("$DISPLAY_NAME:update-script-failed")
+    elif git diff --quiet $LOCKFILE_PATTERN 2>/dev/null; then
+      cleanup_empty_branch "$REPO_BRANCH" "$BRANCH_REF" "$FIX_BRANCH"
+      REPOS_SKIPPED+=("$DISPLAY_NAME:no-changes")
+    else
+      # shellcheck disable=SC2086
+      git add $LOCKFILE_PATTERN || {
+        REPOS_FAILED+=("$DISPLAY_NAME:stage-failed")
+        continue
+      }
+
+      # shellcheck disable=SC2059
+      git commit -s -m "$(printf "$COMMIT_MSG" "$REPO_BRANCH")" || {
+        REPOS_FAILED+=("$DISPLAY_NAME:commit-failed")
+        continue
+      }
+
+      echo "✓ Committed lockfile changes"
+      REPOS_UPDATED+=("$DISPLAY_NAME#$REPO_NAME#$REPO_VERSION#$REPO_BRANCH")
+    fi
+  done
+
+  cd "$ORIGINAL_DIR"
+}
+
+print_section() {
+  local title="$1"
+  local symbol="$2"
+  local -n entries="$3"
+  local show_reason="${4:-false}"
+
+  [ "${#entries[@]}" -eq 0 ] && return
+
+  echo ""
+  echo "$title (${#entries[@]}):"
+  for entry in "${entries[@]}"; do
+    if [ "$show_reason" = "true" ]; then
+      echo "  $symbol ${entry%%:*} (${entry##*:})"
+    else
+      echo "  $symbol ${entry%%#*}"
+    fi
+  done
+}
+
+print_summary() {
+  echo ""
+  echo "Summary"
+
+  print_section "Updated" "✓" REPOS_UPDATED
+  print_section "Skipped" "-" REPOS_SKIPPED true
+  print_section "Failed" "✗" REPOS_FAILED true
+
+  local UPDATED_COUNT=${#REPOS_UPDATED[@]}
+  local FAILED_COUNT=${#REPOS_FAILED[@]}
+
+  if [ "$UPDATED_COUNT" -gt 0 ]; then
+    echo ""
+    echo "Next Steps"
+    for entry in "${REPOS_UPDATED[@]}"; do
+      local display="${entry%%#*}"
+      local rest="${entry#*#}"
+      local repo="${rest%%#*}"
+      rest="${rest#*#}"
+      local version="${rest%%#*}"
+      local branch="${rest#*#}"
+      echo ""
+      echo "# $display"
+      echo "cd $SUBMARINER_BASE/$repo"
+      echo "git show"
+      echo "git push origin update-rpm-lockfiles-${version}"
+      echo "gh pr create --base $branch --head update-rpm-lockfiles-${version}"
+    done
+  fi
+
+  echo ""
+  [ "$FAILED_COUNT" -eq 0 ]
+}
+
+main() {
+  check_prerequisites
+  parse_arguments "$@"
+  update_lockfiles
+  print_summary
+}
+
+main "$@"

--- a/skills/create-component-release/SKILL.md
+++ b/skills/create-component-release/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools: Bash
 
 # Create Component Release
 
-Automates Step 8 (stage), and Step 15 (prod) of the Submariner release workflow.
+Automates Step 8 (stage) and Step 15 (prod) of the Submariner release workflow.
 
 **What it does:**
 

--- a/skills/rpm-lockfile-update/SKILL.md
+++ b/skills/rpm-lockfile-update/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: rpm-lockfile-update
+description: Update RPM lockfiles across Submariner repositories
+version: 2.0.0
+argument-hint: "[branch] [repo|component]"
+user-invocable: true
+allowed-tools: Bash
+---
+
+# RPM Lockfile Update
+
+Regenerates RPM lockfiles in submariner and shipyard repositories by creating fix branches, running hermetic builds,
+and committing updated lockfiles.
+
+```bash
+/rpm-lockfile-update                             # Auto-detect branch, all repos
+/rpm-lockfile-update 0.21                        # Explicit branch, all repos
+/rpm-lockfile-update gateway                     # Auto-detect branch, gateway only
+/rpm-lockfile-update 0.21 submariner             # Explicit branch, repo filter
+make rpm-lockfile-update                         # Auto-detect branch
+make rpm-lockfile-update COMPONENT=gateway       # Auto-detect, component filter
+make rpm-lockfile-update BRANCH=0.21 COMPONENT=gateway  # Explicit branch
+```
+
+**Filter options:** all, submariner, shipyard, gateway, globalnet, route-agent, nettest
+
+**Requirements:** Red Hat entitlements, `podman login registry.redhat.io`, `gh auth login`, Bash 4.0+
+
+**Arguments:** $ARGUMENTS
+
+---
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# Find git repository root
+GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$GIT_ROOT" ]; then
+  echo "❌ Not in a git repository"
+  exit 1
+fi
+
+# Verify orchestrator script exists
+if [ ! -x "$GIT_ROOT/scripts/rpm-lockfile-update.sh" ]; then
+  echo "❌ Orchestrator script not found: scripts/rpm-lockfile-update.sh"
+  exit 1
+fi
+
+# Delegate to orchestrator (passes all arguments)
+exec "$GIT_ROOT/scripts/rpm-lockfile-update.sh" $ARGUMENTS
+```


### PR DESCRIPTION
Orchestrates RPM lockfile updates across submariner and shipyard
repositories. Creates fix branches, runs hermetic builds, and commits
updated lockfiles with per-repo tracking and summary reporting.

Components:
- scripts/rpm-lockfile-update.sh: Orchestrator (277 lines)
  - Auto-detects branch from submariner repo
  - Filters by repo (submariner, shipyard) or component (gateway, etc)
  - Tracks results: updated, skipped, failed
  - Shows next steps (push, create PRs)
- skills/rpm-lockfile-update/SKILL.md: Minimal wrapper (52 lines)
  - Delegates to orchestrator script
  - Verbose examples with inline comments
- Makefile: rpm-lockfile-update target
- .claude/SKILLS.md: Skill documentation
- .agents/workflows/scan-cves.md: Reference new skill for RPM CVE fixes

Usage:
  /rpm-lockfile-update [branch] [repo|component]
  make rpm-lockfile-update [BRANCH=0.21] [COMPONENT=gateway]