### PR TITLE
Fix component setup to preserve executable permissions

### DIFF
--- a/skills/konflux-component-setup/SKILL.md
+++ b/skills/konflux-component-setup/SKILL.md
@@ -724,6 +724,7 @@ if [ -n "$SPECIAL_FILES" ]; then
     # nettest has metricsproxy.konflux in scripts/nettest/
     SPECIAL_PATH="scripts/${COMPONENT}/${file}.konflux"
     if git show "origin/release-${VERSION_MAJOR}.${PREV_VERSION}:${SPECIAL_PATH}" > "${SPECIAL_PATH}" 2>/dev/null; then
+      chmod +x "$SPECIAL_PATH"
       if [ -f "$SPECIAL_PATH" ]; then
         echo "✓ Copied special file: $SPECIAL_PATH"
       else


### PR DESCRIPTION
Add chmod +x after copying special files with git show. The git show > redirect creates files with default permissions (644), losing the executable bit from the source.

This fixes the root cause of metricsproxy.konflux being created without execute permissions, which caused "Operation not permitted" errors in nettest containers on release-0.23.