### PR TITLE
Optimize CVE verification by caching Clair reports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,10 @@ verify-cve-fixes:
 
 test: validate-yaml validate-fields validate-data validate-markdown gitlint shellcheck
 
-test-remote: test validate-references validate-bundle-images validate-cve-fixes
+test-remote:
+	@test -n "$(FILE)" || (echo "ERROR: FILE parameter required. Usage: make test-remote FILE=releases/..." && exit 1)
+	@$(MAKE) test
+	@$(MAKE) validate-references validate-bundle-images validate-cve-fixes
 
 validate-references:
 	./scripts/validate-release-references.sh $(FILE)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ make rpm-lockfile-update COMPONENT=gateway       # Filter by component
 make test
 
 # Validate with cluster checks and CVE verification (requires cluster login)
-make test-remote
+make test-remote FILE=releases/0.22/stage/submariner-0-22-1-stage-20260319-01.yaml
 
 # Apply release (requires cluster login)
 make apply FILE=releases/0.20/stage/submariner-0-20-2-stage-20250930-01.yaml
@@ -40,9 +40,7 @@ make watch NAME=submariner-0-20-2-stage-20250930-01
 make add-release-notes VERSION=0.22.1                          # Auto-find latest stage YAML
 make add-release-notes VERSION=0.22.1 STAGE_YAML=...           # Use specific YAML
 
-# Verify CVE fixes in snapshot images (requires oc login)
-# Checks Clair reports to confirm CVEs are actually fixed
-# Run automatically by add-release-notes, or manually for re-verification
+# Verify CVE fixes via Clair reports (requires oc login, auto-runs in add-release-notes)
 make verify-cve-fixes STAGE_YAML=releases/0.22/stage/submariner-0-22-1-stage-20260319-01.yaml
 
 # Setup acli (one-time)

--- a/scripts/release-notes/auto-apply.sh
+++ b/scripts/release-notes/auto-apply.sh
@@ -58,9 +58,9 @@ if [[ "$CVE_COUNT" -gt 0 ]]; then
     (.issues | length) as $issue_count |
     (.issues | map(.component)) as $components |
     if $issue_count == 1 then
-      "        # \($cve_key): FIXED\n"
+      "        # \($cve_key): Verified absent in Clair report\n"
     else
-      "        # \($cve_key) (\($issue_count) issues): FIXED\n"
+      "        # \($cve_key) (\($issue_count) issues): Verified absent in Clair reports\n"
     end +
     ($components | map("        - key: \($cve_key)\n          component: \(.)") | join("\n"))
   ' "$TOPICS_JSON")
@@ -88,29 +88,14 @@ validate_stage_yaml "$STAGE_YAML"
 
 echo "Preparing commit..."
 
-RATIONALE=$(jq -r --argjson cve_count "$CVE_COUNT" --argjson non_cve_count "$NON_CVE_COUNT" '
-  if $cve_count > 0 then
-    "Security release: \($cve_count) CVEs, \($non_cve_count) other fixes"
-  elif .statistics.non_cve_blocker > 0 then
-    "Fixes: \(.statistics.non_cve_blocker) blocker, \(.statistics.non_cve_critical) critical, \(.statistics.non_cve_major) major"
-  elif .statistics.non_cve_critical > 0 then
-    "Fixes: \(.statistics.non_cve_critical) critical, \(.statistics.non_cve_major) major"
-  else
-    "Bug fixes and enhancements"
-  end
-' "$TOPICS_JSON")
-
-COMMIT_MSG="Add release notes for $VERSION (auto-applied)
+COMMIT_MSG="Add release notes for $VERSION
 
 Type: $RELEASE_TYPE
 CVE issues: $CVE_COUNT
 Non-CVE issues: $NON_CVE_COUNT
 
-Rationale:
-$RATIONALE
-
-All filtered issues auto-included. Review and amend to remove
-any that don't belong in release notes."
+All filtered issues auto-applied. Review commit and amend to
+remove any that don't belong in release notes."
 
 commit_release_notes "$STAGE_YAML" "$COMMIT_MSG" "auto-applied"
 

--- a/scripts/release-notes/verify-cve-fixes.sh
+++ b/scripts/release-notes/verify-cve-fixes.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
-# Phase 4: Verify CVE fixes in snapshot container images
-# Output: Updated YAML with verification comments
+# Phase 4: Verify CVE fixes in snapshot container images via Clair reports
+# Reports which CVEs are actually fixed vs still present
 set -euo pipefail
 
 # ============================================================================
 # Argument Parsing
 # ============================================================================
-
-STAGE_YAML=""
 
 if [[ $# -eq 0 ]]; then
   echo "Usage: $0 STAGE_YAML" >&2
@@ -21,7 +19,7 @@ if [[ ! -f "$STAGE_YAML" ]]; then
   exit 1
 fi
 
-# Convert to absolute path (script changes directories during execution)
+# Convert to absolute path for robustness
 STAGE_YAML=$(realpath "$STAGE_YAML")
 
 # ============================================================================
@@ -49,7 +47,6 @@ if [[ -z "$SNAPSHOT" || "$SNAPSHOT" == "null" ]]; then
 fi
 echo "Snapshot: $SNAPSHOT"
 
-# Extract unique CVEs from YAML
 CVE_LIST=$(yq eval '.spec.data.releaseNotes.cves[].key' "$STAGE_YAML" 2>/dev/null | sort -u || echo "")
 if [[ -z "$CVE_LIST" ]]; then
   echo "No CVEs in YAML - skipping verification"
@@ -58,6 +55,16 @@ fi
 
 CVE_COUNT=$(echo "$CVE_LIST" | wc -l)
 echo "Found $CVE_COUNT unique CVEs to verify"
+
+# Build CVE → components mapping
+declare -A CVE_COMPONENTS
+while IFS=$'\t' read -r CVE COMPONENT; do
+  if [[ -n "${CVE_COMPONENTS[$CVE]:-}" ]]; then
+    CVE_COMPONENTS["$CVE"]+=" $COMPONENT"
+  else
+    CVE_COMPONENTS["$CVE"]="$COMPONENT"
+  fi
+done < <(yq eval '.spec.data.releaseNotes.cves[] | [.key, .component] | @tsv' "$STAGE_YAML" | sort -u)
 
 # ============================================================================
 # Get Component Images from Snapshot
@@ -71,8 +78,7 @@ if ! oc get snapshot "$SNAPSHOT" -n submariner-tenant &>/dev/null; then
   exit 1
 fi
 
-# Get all component images (name → image)
-declare -A COMPONENT_IMAGES
+declare -A COMPONENT_IMAGES  # name → image
 while IFS=$'\t' read -r NAME IMAGE; do
   COMPONENT_IMAGES["$NAME"]="$IMAGE"
 done < <(oc get snapshot "$SNAPSHOT" -n submariner-tenant -o json | \
@@ -81,87 +87,118 @@ done < <(oc get snapshot "$SNAPSHOT" -n submariner-tenant -o json | \
 echo "Found ${#COMPONENT_IMAGES[@]} components in snapshot"
 
 # ============================================================================
-# Verify Each CVE+Component Pair
+# Pull Clair Reports (once per unique component)
 # ============================================================================
 
-echo "Verifying CVE fixes in Clair reports..."
+echo "Pulling Clair reports..."
 
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
-# Track verification results: CVE → (VERIFIED_FIXED|NOT_FIXED|MIXED)
+UNIQUE_COMPONENTS=$(printf '%s\n' "${CVE_COMPONENTS[@]}" | tr ' ' '\n' | sort -u | grep -v '^$')
+
+declare -A CLAIR_REPORTS
+
+for COMPONENT in $UNIQUE_COMPONENTS; do
+  IMAGE="${COMPONENT_IMAGES[$COMPONENT]:-}"
+  if [[ -z "$IMAGE" ]]; then
+    echo "  $COMPONENT: ⚠️  Not in snapshot (skipping)"
+    continue
+  fi
+
+  # Get arch-specific digest (Clair reports attach to architecture-specific
+  # digest, not the multi-arch manifest digest)
+  ARCH_DIGEST=$(skopeo inspect --raw "docker://$IMAGE" 2>/dev/null | \
+    jq -r '.manifests[]? | select(.platform.architecture=="amd64") | .digest' || echo "")
+
+  if [[ -z "$ARCH_DIGEST" ]]; then
+    echo "  $COMPONENT: ⚠️  No amd64 digest (skipping)"
+    continue
+  fi
+
+  IMAGE_REPO="${IMAGE%%@*}"
+
+  # Find Clair report
+  CLAIR_DIGEST=$(oras discover "${IMAGE_REPO}@${ARCH_DIGEST}" \
+    --artifact-type "application/vnd.redhat.clair-report+json" -o json 2>/dev/null | \
+    jq -r '.manifests[0].digest // empty' || echo "")
+
+  if [[ -z "$CLAIR_DIGEST" ]]; then
+    echo "  $COMPONENT: ⚠️  No Clair report (skipping)"
+    continue
+  fi
+
+  # Pull Clair report to dedicated directory
+  COMPONENT_DIR="$TMPDIR/$COMPONENT"
+  mkdir -p "$COMPONENT_DIR"
+
+  if ! oras pull "${IMAGE_REPO}@${CLAIR_DIGEST}" --output "$COMPONENT_DIR" &>/dev/null; then
+    echo "  $COMPONENT: ⚠️  Failed to pull report (skipping)"
+    continue
+  fi
+
+  REPORT_FILE="$COMPONENT_DIR/clair-report-amd64.json"
+  if [[ ! -f "$REPORT_FILE" ]]; then
+    echo "  $COMPONENT: ⚠️  Report file not found (skipping)"
+    continue
+  fi
+
+  CLAIR_REPORTS["$COMPONENT"]="$REPORT_FILE"
+  echo "  $COMPONENT: ✓ Clair report cached"
+done
+
+if [[ ${#CLAIR_REPORTS[@]} -eq 0 ]]; then
+  echo ""
+  echo "❌ ERROR: No Clair reports could be retrieved"
+  exit 1
+fi
+
+echo "Cached ${#CLAIR_REPORTS[@]} Clair reports"
+
+# ============================================================================
+# Verify Each CVE Across All Components
+# ============================================================================
+
+echo ""
+echo "Verifying CVE fixes..."
+
 declare -A CVE_RESULTS
 
 for CVE in $CVE_LIST; do
   echo ""
   echo "Checking $CVE..."
 
-  # Get all components for this CVE from YAML
-  COMPONENTS=$(yq eval ".spec.data.releaseNotes.cves[] | select(.key == \"$CVE\") | .component" "$STAGE_YAML" | sort -u)
-
+  COMPONENTS="${CVE_COMPONENTS[$CVE]}"
   FIXED_COUNT=0
   NOT_FIXED_COUNT=0
   ERROR_COUNT=0
 
   for COMPONENT in $COMPONENTS; do
-    IMAGE="${COMPONENT_IMAGES[$COMPONENT]:-}"
+    CLAIR_REPORT="${CLAIR_REPORTS[$COMPONENT]:-}"
 
-    if [[ -z "$IMAGE" ]]; then
-      echo "  $COMPONENT: ⚠️  Not in snapshot"
+    if [[ -z "$CLAIR_REPORT" ]]; then
+      echo "  $COMPONENT: ⚠️  No Clair report cached"
       ERROR_COUNT=$((ERROR_COUNT + 1))
       continue
     fi
 
-    # Get arch-specific digest (Clair reports attach to arch digest, not multi-arch manifest)
-    ARCH_DIGEST=$(skopeo inspect --raw "docker://$IMAGE" 2>/dev/null | \
-      jq -r '.manifests[]? | select(.platform.architecture=="amd64") | .digest' || echo "")
-
-    if [[ -z "$ARCH_DIGEST" ]]; then
-      echo "  $COMPONENT: ⚠️  No amd64 digest found"
-      ERROR_COUNT=$((ERROR_COUNT + 1))
-      continue
-    fi
-
-    IMAGE_REPO=$(echo "$IMAGE" | cut -d@ -f1)
-
-    # Find Clair report
-    CLAIR_DIGEST=$(oras discover "${IMAGE_REPO}@${ARCH_DIGEST}" \
-      --artifact-type "application/vnd.redhat.clair-report+json" -o json 2>/dev/null | \
-      jq -r '.manifests[0].digest // empty' || echo "")
-
-    if [[ -z "$CLAIR_DIGEST" ]]; then
-      echo "  $COMPONENT: ⚠️  No Clair report found"
-      ERROR_COUNT=$((ERROR_COUNT + 1))
-      continue
-    fi
-
-    # Pull and check Clair report
-    cd "$TMPDIR"
-    rm -f clair-report-*.json
-    if ! oras pull "${IMAGE_REPO}@${CLAIR_DIGEST}" &>/dev/null; then
-      echo "  $COMPONENT: ⚠️  Failed to pull Clair report"
-      ERROR_COUNT=$((ERROR_COUNT + 1))
-      continue
-    fi
-
-    CLAIR_REPORT=$(ls clair-report-*.json 2>/dev/null | head -1)
-    if [[ -z "$CLAIR_REPORT" || ! -f "$CLAIR_REPORT" ]]; then
-      echo "  $COMPONENT: ⚠️  Clair report file not found"
-      ERROR_COUNT=$((ERROR_COUNT + 1))
-      continue
-    fi
-
-    # Check if CVE present in report (CVEs keyed by hash, .name has actual CVE-ID)
+    # Check if CVE present in report
+    # Note: Clair JSON uses hashed keys, CVE ID is in .value.name field
     if jq -e ".vulnerabilities | to_entries[] | select(.value.name == \"$CVE\")" "$CLAIR_REPORT" &>/dev/null; then
-      echo "  $COMPONENT: ❌ CVE PRESENT in Clair report"
+      echo "  $COMPONENT: ❌ CVE PRESENT"
       NOT_FIXED_COUNT=$((NOT_FIXED_COUNT + 1))
     else
-      echo "  $COMPONENT: ✓ CVE absent in Clair report"
+      echo "  $COMPONENT: ✓ CVE absent"
       FIXED_COUNT=$((FIXED_COUNT + 1))
     fi
   done
 
   # Determine overall result for this CVE
+  # Result states:
+  #   NOT_FIXED: CVE present in at least one component (blocks release)
+  #   VERIFIED_FIXED: CVE absent in all components, no errors
+  #   PARTIAL: CVE absent in some, errors prevented checking others
+  #   ERROR: All components failed verification
   if [[ $NOT_FIXED_COUNT -gt 0 ]]; then
     CVE_RESULTS["$CVE"]="NOT_FIXED"
   elif [[ $FIXED_COUNT -gt 0 && $ERROR_COUNT -eq 0 ]]; then
@@ -179,27 +216,27 @@ done
 
 echo ""
 echo "=== Verification Summary ==="
-VERIFIED_COUNT=0
-NOT_FIXED_COUNT=0
-ERROR_COUNT=0
+SUMMARY_VERIFIED=0
+SUMMARY_NOT_FIXED=0
+SUMMARY_ERROR=0
 
 for CVE in $CVE_LIST; do
   RESULT="${CVE_RESULTS[$CVE]:-UNKNOWN}"
   case "$RESULT" in
-    VERIFIED_FIXED) VERIFIED_COUNT=$((VERIFIED_COUNT + 1)) ;;
-    NOT_FIXED) NOT_FIXED_COUNT=$((NOT_FIXED_COUNT + 1)) ;;
-    *) ERROR_COUNT=$((ERROR_COUNT + 1)) ;;
+    VERIFIED_FIXED) SUMMARY_VERIFIED=$((SUMMARY_VERIFIED + 1)) ;;
+    NOT_FIXED) SUMMARY_NOT_FIXED=$((SUMMARY_NOT_FIXED + 1)) ;;
+    *) SUMMARY_ERROR=$((SUMMARY_ERROR + 1)) ;;
   esac
 done
 
 echo "Total CVEs: $CVE_COUNT"
-echo "  ✓ Verified fixed: $VERIFIED_COUNT"
-echo "  ❌ NOT fixed: $NOT_FIXED_COUNT"
-echo "  ⚠️  Errors/Partial: $ERROR_COUNT"
+echo "  ✓ Verified fixed: $SUMMARY_VERIFIED"
+echo "  ❌ NOT fixed: $SUMMARY_NOT_FIXED"
+echo "  ⚠️  Errors/Partial: $SUMMARY_ERROR"
 
-if [[ $NOT_FIXED_COUNT -gt 0 ]]; then
+if [[ $SUMMARY_NOT_FIXED -gt 0 ]]; then
   echo ""
-  echo "❌ VERIFICATION FAILED: $NOT_FIXED_COUNT CVE(s) still present in Clair reports"
+  echo "❌ VERIFICATION FAILED: $SUMMARY_NOT_FIXED CVE(s) still present in Clair reports"
   echo "Review and remove these CVEs from YAML via: git commit --amend"
   exit 1
 fi


### PR DESCRIPTION
Refactor verify-cve-fixes.sh to pull each component's Clair report once, then verify all CVEs against the cached reports. Previously pulled reports redundantly for each CVE+component check.

Also other docs/refactoring for verify-cve-fixes.