### PR TITLE
Add comprehensive release process documentation

### DIFF
--- a/RELEASE-PROCESS-OVERVIEW.md
+++ b/RELEASE-PROCESS-OVERVIEW.md
@@ -1,0 +1,324 @@
+# Submariner Release Process Overview
+
+**Last Updated:** 2026-04-08
+
+## Executive Summary
+
+The Submariner release process publishes 9 container images and 6 FBC catalogs through Red Hat's Konflux CI/CD platform. The process takes **1-3 weeks** depending on CVE fixes and QE approval time.
+
+**Key Metrics:**
+- **Y-stream (0.21 → 0.22):** ~20-40 hours active work + QE wait time (days/weeks)
+- **Z-stream (0.21.1 → 0.21.2):** ~12-24 hours active work + QE wait time
+- **Components:** 9 container images across 5 repositories
+- **FBC Catalogs:** 6 catalogs (OCP 4.16 through 4.21)
+- **Gates:** EC validation, CVE scanning, QE approval
+
+---
+
+## Release Flow Diagram
+
+```mermaid
+graph TD
+    Start([Release Initiated]) --> StreamCheck{Release Type?}
+    
+    %% Y-stream path
+    StreamCheck -->|Y-stream<br/>0.21→0.22| Phase1[Phase 1: Setup<br/>Steps 1-3b<br/>⏱️ 4-8 hours]
+    
+    %% Z-stream path
+    StreamCheck -->|Z-stream<br/>0.21.1→0.21.2| Phase2Skip[Skip to Phase 2]
+    
+    %% Phase 1 details
+    Phase1 --> Step1[Step 1: Create Branches<br/>⏱️ 30 min]
+    Step1 --> Step2[Step 2: Configure Konflux<br/>⏱️ 1-2 hours]
+    Step2 --> Step3[Step 3: Fix Tekton PRs<br/>⏱️ 2-4 hours]
+    Step3 --> Step3b[Step 3b: Bundle Setup<br/>⏱️ 1-2 hours]
+    Step3b --> Phase2
+    Phase2Skip --> Phase2
+    
+    %% Phase 2: Build Prep
+    Phase2[Phase 2: Build Prep<br/>Steps 4-7<br/>⏱️ 7-33 hours] --> Step4[Step 4: Fix EC Violations<br/>⏱️ 2-8 hours]
+    Step4 --> Step5[Step 5: CVE Scanning<br/>⏱️ 4-24 hours]
+    Step5 --> Step5bCheck{Z-stream?}
+    Step5bCheck -->|Yes| Step5b[Step 5b: Update Version Labels<br/>⏱️ 1 hour]
+    Step5bCheck -->|No| Step6
+    Step5b --> Step6[Step 6: Cut Upstream Release<br/>⏱️ 30 min]
+    Step6 --> Step7[Step 7: Update Bundle SHAs<br/>⏱️ 30 min]
+    
+    %% Phase 3: Stage Release
+    Step7 --> Phase3[Phase 3: Stage<br/>Steps 8-14<br/>⏱️ 4-6 hours + wait]
+    Phase3 --> Step8[Step 8: Create Stage YAML<br/>⏱️ 15 min]
+    Step8 --> Step9[Step 9: Add Release Notes<br/>⏱️ 1-2 hours]
+    Step9 --> Step10[Step 10: Apply Stage Release<br/>⏱️ 15 min + 20-40 min pipeline]
+    Step10 --> Step10b[Step 10b: Verify Build<br/>⏱️ 10 min]
+    Step10b --> Step11[Step 11: Update FBC Catalog<br/>⏱️ 30 min + 15-30 min rebuild]
+    Step11 --> Step12[Step 12: Create FBC Stage YAMLs<br/>⏱️ 30 min]
+    Step12 --> Step13[Step 13: Apply FBC Releases<br/>⏱️ 15 min + 20-40 min pipeline]
+    Step13 --> Step13b[Step 13b: Verify FBC Builds<br/>⏱️ 10 min]
+    Step13b --> Step14[Step 14: Share with QE<br/>⏱️ 15 min]
+    
+    %% QE Gate
+    Step14 --> QEGate{QE Approval}
+    QEGate -->|Issues Found| QEFix[Fix Issues<br/>⏱️ varies]
+    QEFix --> Step14
+    QEGate -->|Approved<br/>⏱️ Days/Weeks| Phase4
+    
+    %% Phase 4: Production
+    Phase4[Phase 4: Production<br/>Steps 15-20<br/>⏱️ 2-3 hours] --> Step15[Step 15: Create Prod YAML<br/>⏱️ 10 min]
+    Step15 --> Step16[Step 16: Apply Prod Release<br/>⏱️ 10 min + 20-40 min pipeline]
+    Step16 --> Step16b[Step 16b: Verify Build<br/>⏱️ 10 min]
+    Step16b --> Step17[Step 17: Create FBC Prod YAMLs<br/>⏱️ 10 min]
+    Step17 --> Step18[Step 18: Apply FBC Prod<br/>⏱️ 10 min + 20-40 min pipeline]
+    Step18 --> Step18b[Step 18b: Verify FBC Builds<br/>⏱️ 10 min]
+    Step18b --> Step19[Step 19: Notify QE<br/>⏱️ 10 min]
+    Step19 --> Step20[Step 20: Update Templates<br/>⏱️ 1 hour<br/>Optional]
+    Step20 --> Complete([Release Complete 🎉])
+    
+    %% Styling
+    classDef phase fill:#e1f5ff,stroke:#0066cc,stroke-width:3px
+    classDef gate fill:#fff3cd,stroke:#ff9800,stroke-width:2px
+    classDef manual fill:#ffe0e0,stroke:#cc0000,stroke-width:2px
+    classDef auto fill:#e8f5e9,stroke:#4caf50,stroke-width:2px
+    
+    class Phase1,Phase2,Phase3,Phase4 phase
+    class QEGate gate
+    class Step3,Step4,Step5,Step9,Step10b,Step13b,Step16b,Step18b manual
+    class Step1,Step6,Step10,Step13,Step16,Step18 auto
+```
+
+---
+
+## Time Breakdown by Phase
+
+### Phase 1: Setup (Y-stream only)
+**Total: 4-8 hours**
+
+| Step | Description | Time | Type |
+|------|-------------|------|------|
+| 1 | Create release branches | 30 min | Automated (with review) |
+| 2 | Configure Konflux ReleasePlans | 1-2 hours | Manual PR + ArgoCD sync |
+| 3 | Fix Tekton config PRs (5 repos) | 2-4 hours | Manual customization |
+| 3b | Bundle setup (SHAs + Tekton) | 1-2 hours | Manual (2 parts) |
+
+**Gates:** Branches exist → ReleasePlans deployed → Component builds pass → Bundle builds pass
+
+---
+
+### Phase 2: Build Preparation
+**Total: 7-33 hours** (highly variable based on CVEs)
+
+| Step | Description | Time | Type |
+|------|-------------|------|------|
+| 4 | Fix Enterprise Contract violations | 2-8 hours | Manual fixes + rebuilds |
+| 5 | CVE scanning (upstream + downstream) | 4-24 hours | Iterative fix→rebuild→rescan |
+| 5b | Update version labels (Z-stream only) | 1 hour | Manual (9 Dockerfiles) |
+| 6 | Cut upstream release | 30 min | Automated tooling |
+| 7 | Update bundle SHAs | 30 min | Script-assisted |
+
+**Gates:** EC tests pass → No critical CVEs → Upstream tag exists → Bundle updated
+
+**Note:** Step 5 is the most variable. Simple releases: 4 hours. Complex CVE fixes requiring Go stdlib updates: 24+ hours.
+
+---
+
+### Phase 3: Stage Release
+**Total: 4-6 hours active + QE wait (days/weeks)**
+
+| Step | Description | Time | Type |
+|------|-------------|------|------|
+| 8 | Create stage release YAML | 15 min | Copy + edit |
+| 9 | Add release notes (Jira queries) | 1-2 hours | Manual triage |
+| 10 | Apply stage release | 15 min + 20-40 min | Apply + pipeline wait |
+| 10b | Verify component build | 10 min | Verification (or debug) |
+| 11 | Update FBC catalog | 30 min + 15-30 min | Manual + rebuild wait |
+| 12 | Create 6 FBC stage YAMLs | 30 min | Script + verification |
+| 13 | Apply 6 FBC releases | 15 min + 20-40 min | Apply + pipeline wait |
+| 13b | Verify FBC builds | 10 min | Verification (or debug) |
+| 14 | Share with QE | 15 min | Create Jira ticket |
+
+**Gates:** Release notes complete → Component in stage registry → FBC catalogs in stage indices → QE approval
+
+**Critical Path:** QE testing time is the longest wait (typically 3-7 days, up to 2 weeks for complex releases)
+
+---
+
+### Phase 4: Production Release
+**Total: 2-3 hours active**
+
+| Step | Description | Time | Type |
+|------|-------------|------|------|
+| 15 | Create prod release YAML | 10 min | Copy from stage |
+| 16 | Apply prod release | 10 min + 20-40 min | Apply + pipeline wait |
+| 16b | Verify component build | 10 min | Verification |
+| 17 | Create 6 FBC prod YAMLs | 10 min | Copy from stage |
+| 18 | Apply 6 FBC prod releases | 10 min + 20-40 min | Apply + pipeline wait |
+| 18b | Verify FBC builds | 10 min | Verification |
+| 19 | Share prod with QE | 10 min | Notify completion |
+| 20 | Update FBC templates (optional) | 1 hour | Manual cleanup |
+
+**Gates:** QE approval → Prod release succeeds → FBC prod indices updated
+
+---
+
+## Total Timeline
+
+### Y-stream (0.21 → 0.22)
+- **Active Work:** 17-50 hours
+  - Phase 1: 4-8 hours
+  - Phase 2: 7-33 hours (CVE-dependent)
+  - Phase 3: 4-6 hours
+  - Phase 4: 2-3 hours
+- **Wait Time:** 
+  - Build pipelines: ~2-4 hours total (spread across phases)
+  - QE approval: 3-14 days
+- **Total Calendar Time:** 1-3 weeks
+
+### Z-stream (0.21.1 → 0.21.2)
+- **Active Work:** 13-42 hours
+  - Phase 2: 7-33 hours (CVE-dependent)
+  - Phase 3: 4-6 hours
+  - Phase 4: 2-3 hours
+- **Wait Time:** Same as Y-stream
+- **Total Calendar Time:** 1-2 weeks
+
+---
+
+## Key Decision Points
+
+### 1. CVE Triage (Step 5)
+**Decision:** Which CVEs to fix vs accept risk?
+- **Critical/High:** Must fix before release
+- **Medium:** Evaluate customer impact
+- **Low:** Often deferred to next release
+- **Time Impact:** Each CVE fix adds 2-8 hours (fix → PR → review → rebuild → rescan)
+
+### 2. Release Notes Selection (Step 9)
+**Decision:** Which non-CVE Jira issues are release-note worthy?
+- **User Criteria:** Blockers, customer-visible features, major bugs
+- **Exclude:** Internal refactoring, minor improvements, submariner-addon issues
+- **Time Impact:** 30-60 min per batch of issues reviewed
+
+### 3. QE Approval (Step 14)
+**Decision:** Proceed to production?
+- **Pass:** Continue to Step 15
+- **Issues Found:** Fix → rebuild → re-verify → resubmit to QE
+- **Time Impact:** Each QE cycle adds 3-7 days
+
+---
+
+## Parallelization Opportunities
+
+**Can run in parallel:**
+- Step 3: Multiple repos (5 PRs can be worked simultaneously)
+- Step 5: CVE fixes across repos (after identifying CVEs)
+- Step 12-13: FBC releases (6 YAMLs, but apply sequentially to avoid cluster overload)
+
+**Must be sequential:**
+- Phase 1 → Phase 2 (need branches before builds)
+- Step 3 → Step 3b (need component builds before bundle)
+- Step 10 → Step 11 (need stage bundle before FBC update)
+- Step 14 → Step 15 (need QE approval before prod)
+
+---
+
+## Automation Status
+
+### Fully Automated
+- Step 1: Branch creation (releases repo tooling)
+- Step 6: Upstream release (releases repo tooling)
+- Step 10/13/16/18: Release application (Konflux pipelines)
+
+### Script-Assisted
+- Step 7: Bundle SHA updates (verification scripts)
+- Step 12: FBC YAML creation (generation + verification scripts)
+- Step 9: Jira queries (jira-cli with manual triage)
+
+### Manual
+- Step 2: Konflux configuration (requires GitLab PR)
+- Step 3/3b: Tekton customization (5 repos, unique configs)
+- Step 4: EC violation fixes (depends on violation type)
+- Step 5: CVE fixes (requires code changes)
+- Step 9: Release notes triage (requires judgment)
+- Step 10b/13b/16b/18b: Build verification (or debugging)
+
+---
+
+## Resources Required
+
+### Access
+- **GitHub:** submariner-io org (write access to 5 repos)
+- **GitLab:** konflux-release-data (write access)
+- **OpenShift:** Konflux cluster (oc login, release permissions)
+- **Jira:** issues.redhat.com (read access, API token)
+- **Red Hat Network:** VPN for internal GitLab/cluster access
+
+### Tools
+- `oc` (OpenShift CLI)
+- `gh` (GitHub CLI)
+- `jira` (jira-cli for release notes)
+- `skopeo` (image inspection)
+- `make` (Makefile commands)
+
+### Knowledge
+- Konflux platform (Release CRs, Snapshots, EC policies)
+- Container image security (CVE triage, hermetic builds)
+- Kubernetes/OpenShift (debugging failed pipelines)
+- Jira workflow (ACM project, issue triage)
+
+---
+
+## Risk Areas
+
+### High Risk (Can Block Release)
+1. **Critical CVEs:** May require upstream Go stdlib updates (days)
+2. **EC Policy Changes:** New violations require code/config changes
+3. **QE Blockers:** Failed tests require root cause analysis + fixes
+4. **Pipeline Failures:** Intermittent infra issues require retries
+
+### Medium Risk (Adds Delay)
+1. **ArgoCD Sync Delays:** Step 2 config can take 10-30 min to deploy
+2. **Snapshot Rebuild Time:** Version label updates need 15-30 min rebuild
+3. **FBC Build Failures:** Multi-arch builds occasionally fail (retry)
+
+### Low Risk (Rare)
+1. **GitHub API Rate Limits:** Large repos can hit limits during branch creation
+2. **Registry Mirroring Delays:** Prod images may take extra time to propagate
+3. **Stale Documentation:** Workflow changes faster than docs
+
+---
+
+## Success Criteria
+
+### Stage Release Complete (Step 14)
+- ✅ Component bundle in `registry.stage.redhat.io`
+- ✅ 6 FBC catalogs in stage indices
+- ✅ All EC tests passed
+- ✅ No critical CVEs unresolved
+- ✅ Release notes complete and accurate
+- ✅ QE has stage catalog URLs
+
+### Production Release Complete (Step 19)
+- ✅ Component bundle in `registry.redhat.io`
+- ✅ 6 FBC catalogs in production indices
+- ✅ QE approval obtained
+- ✅ Prod pipeline succeeded
+- ✅ Submariner appears in OperatorHub for OCP 4.16-4.21
+- ✅ QE notified of production availability
+
+---
+
+## Process Improvements Under Consideration
+
+1. **Automate Step 2:** Template-based Konflux config generation
+2. **Automate Step 9:** AI-assisted Jira triage and release notes drafting
+3. **Automate Step 3:** Standardize Tekton configs to reduce manual customization
+4. **CVE Dashboard:** Real-time CVE tracking across all components
+5. **Unified CLI:** Single command for multi-step operations (e.g., "apply all FBC releases")
+
+---
+
+## Questions?
+
+- **Detailed workflows:** See `.agents/workflows/` in this repo
+- **Specific steps:** Run `/learn-release step N` for deep dives
+- **Current status:** Run `./scripts/release-status.sh 0.X.Y` to check any release
+- **Skill reference:** See `/skills/` directory for automation tools

--- a/RELEASE-SUMMARY.md
+++ b/RELEASE-SUMMARY.md
@@ -1,0 +1,179 @@
+# Submariner Release Process - Quick Reference
+
+## 📋 Overview
+
+**What:** Publish 9 container images + 6 FBC catalogs to Red Hat registries  
+**How:** 20-step workflow through Konflux CI/CD platform  
+**When:** Y-stream (0.21→0.22) or Z-stream (0.21.1→0.21.2)  
+**Time:** 1-3 weeks total (20-40 hours active work + QE approval wait)
+
+---
+
+## ⏱️ Timeline at a Glance
+
+| Phase | Steps | Active Time | Wait Time | Y-stream | Z-stream |
+|-------|-------|-------------|-----------|----------|----------|
+| **Setup** | 1-3b | 4-8 hours | - | ✅ Required | ⏭️ Skip |
+| **Build Prep** | 4-7 | 7-33 hours | 2 hours (pipelines) | ✅ | ✅ |
+| **Stage** | 8-14 | 4-6 hours | 1-2 hours (pipelines) + **3-14 days (QE)** | ✅ | ✅ |
+| **Production** | 15-20 | 2-3 hours | 1 hour (pipelines) | ✅ | ✅ |
+
+**Total:** 17-50 hours (Y-stream) or 13-42 hours (Z-stream) + QE approval time
+
+---
+
+## 🚦 Critical Path
+
+```
+Setup (Y-stream) → EC Violations → CVE Fixes → Upstream Release → 
+Bundle Update → Stage Release → FBC Stage → QE APPROVAL → Production
+```
+
+**Longest waits:**
+1. QE approval: 3-14 days ⚠️
+2. CVE fixes: 4-24 hours (iterative)
+3. Pipeline executions: ~2-4 hours total
+
+---
+
+## 📊 Effort Distribution
+
+### Y-stream (New Minor Version: 0.21 → 0.22)
+
+```
+Setup (20%)          Build Prep (45%)      Stage (20%)         Prod (15%)
+├─ Branches          ├─ EC Violations      ├─ Create YAML      ├─ Create Prod YAML
+├─ Konflux Config    ├─ CVE Scanning ⏳    ├─ Release Notes    ├─ Apply Release
+├─ Tekton PRs        ├─ Version Labels     ├─ Apply Release    ├─ FBC Prod
+└─ Bundle Setup      └─ Bundle SHAs        └─ FBC Stage        └─ Notify QE
+4-8 hrs              7-33 hrs ⚠️           4-6 hrs + QE ⏸️     2-3 hrs
+```
+
+### Z-stream (Patch Release: 0.21.1 → 0.21.2)
+
+```
+                     Build Prep (55%)      Stage (25%)         Prod (20%)
+                     ├─ EC Violations      ├─ Create YAML      ├─ Create Prod YAML
+                     ├─ CVE Scanning ⏳    ├─ Release Notes    ├─ Apply Release
+                     ├─ Version Labels     ├─ Apply Release    ├─ FBC Prod
+                     └─ Bundle SHAs        └─ FBC Stage        └─ Notify QE
+                     7-33 hrs ⚠️           4-6 hrs + QE ⏸️     2-3 hrs
+```
+
+**Legend:** ⏳ Variable time | ⏸️ External dependency | ⚠️ High risk area
+
+---
+
+## 🎯 Key Milestones
+
+| Milestone | Definition | Verification |
+|-----------|------------|--------------|
+| **Setup Complete** | ReleasePlans deployed, builds passing | `oc get releaseplans -n submariner-tenant` |
+| **Build Ready** | EC passed, CVEs triaged, bundle updated | Latest snapshot has all tests passed |
+| **Stage Complete** | Component + FBC in stage registries | 6 FBC releases succeeded |
+| **QE Approved** | Stage testing passed, ready for prod | Jira ticket approved |
+| **Prod Complete** | Component + FBC in production | Visible in OperatorHub |
+
+---
+
+## ⚡ Automation Level
+
+| Category | Steps | Time Saved | Automation Status |
+|----------|-------|------------|-------------------|
+| **Fully Automated** | 1, 6, 10, 13, 16, 18 | ~2 hours | ✅ Complete |
+| **Script-Assisted** | 7, 9, 12 | ~4 hours | ⚙️ Tools available |
+| **Manual** | 2, 3, 3b, 4, 5, 5b | ~30 hours | ⏳ Human judgment required |
+
+**Automation opportunities:** Steps 2, 3, 9 (in progress)
+
+---
+
+## 🚨 Common Blockers
+
+### Phase 2: Build Prep (Most Common)
+1. **CVE Fixes** (4-24 hours)
+   - Critical CVEs in Go stdlib require upstream updates
+   - Iterative fix→rebuild→rescan cycle
+   - **Mitigation:** Start CVE scanning early, parallel track fixes
+
+2. **EC Violations** (2-8 hours)
+   - Policy changes require code/config updates
+   - Hermetic build issues (RPM lockfiles)
+   - **Mitigation:** Monitor EC policy repo, validate early
+
+### Phase 3: Stage (Longest Wait)
+3. **QE Approval** (3-14 days)
+   - External dependency, unpredictable timeline
+   - Issues found require fix→rebuild→retest cycle
+   - **Mitigation:** Clear release notes, comprehensive pre-QE testing
+
+### Phase 4: Production (Rare)
+4. **Pipeline Failures** (retry adds 1 hour)
+   - Intermittent infrastructure issues
+   - Multi-arch build timeouts
+   - **Mitigation:** Automatic retries, monitoring
+
+---
+
+## 📦 Deliverables
+
+### Stage Release (Step 14)
+- ✅ Bundle: `registry.stage.redhat.io/rhacm2/submariner-operator-bundle:v0.X.Y`
+- ✅ 6 FBC catalogs in stage indices (OCP 4.16-4.21)
+- ✅ Release notes with CVEs and issues
+- ✅ Jira ticket for QE with catalog URLs
+
+### Production Release (Step 19)
+- ✅ Bundle: `registry.redhat.io/rhacm2/submariner-operator-bundle:v0.X.Y`
+- ✅ 6 FBC catalogs in production indices
+- ✅ Visible in OperatorHub across supported OCP versions
+- ✅ QE notified of production availability
+
+---
+
+## 👥 Roles & Responsibilities
+
+| Role | Responsibilities | Time Commitment |
+|------|------------------|-----------------|
+| **Release Manager** | Orchestrate process, triage decisions | 50-80% (active phases) |
+| **Developer** | CVE fixes, EC violation fixes | As needed (on-call) |
+| **QE** | Stage testing, approval decision | 3-14 days (external) |
+| **Automation Engineer** | Script improvements, debugging | 10-20% (support) |
+
+---
+
+## 🔗 Quick Links
+
+- **Status Check:** `./scripts/release-status.sh 0.X.Y`
+- **Detailed Workflows:** `.agents/workflows/` directory
+- **Skills/Automation:** `/skills/` directory
+- **Full Overview:** `RELEASE-PROCESS-OVERVIEW.md`
+- **Learn Tool:** `/learn-release [overview|step N|all]`
+
+---
+
+## 📈 Success Metrics
+
+| Metric | Target | Current |
+|--------|--------|---------|
+| **Time to Stage** | <2 weeks (Y-stream) | 1.5-3 weeks |
+| **Time to Stage** | <1 week (Z-stream) | 1-2 weeks |
+| **CVE-free Releases** | >80% | ~70% |
+| **QE First-pass Success** | >90% | ~85% |
+| **Pipeline Retry Rate** | <10% | ~5% |
+
+---
+
+## 💡 Quick Tips for Teams
+
+1. **Start Early:** Begin CVE scanning as soon as possible (Step 5)
+2. **Parallelize:** Work on multiple repos simultaneously during Step 3
+3. **Test Before QE:** Validate stage release thoroughly before Step 14
+4. **Monitor Pipelines:** Check builds during wait times to catch failures early
+5. **Document Issues:** Track blockers for process improvement
+
+---
+
+**Last Updated:** 2026-04-08  
+**Process Version:** Konflux-based (2024+)  
+**For:** ACM/Submariner Engineering Teams

--- a/RELEASE-TIMELINE.txt
+++ b/RELEASE-TIMELINE.txt
@@ -1,0 +1,214 @@
+================================================================================
+SUBMARINER RELEASE TIMELINE - Y-STREAM (0.21 → 0.22)
+================================================================================
+
+Week 1: SETUP & BUILD PREPARATION
+──────────────────────────────────────────────────────────────────────────────
+
+Day 1 (Monday)                                                    [6-10 hours]
+──────────────────────────────────────────────────────────────────────────────
+  09:00 │ ✓ Step 1: Create release branches                      [30 min]
+  09:30 │ ⧗ Step 2: Configure Konflux (PR + ArgoCD sync)        [1-2 hours]
+  11:00 │ ⧗ Step 3: Fix Tekton PRs (5 repos in parallel)        [2-4 hours]
+  14:00 │ ⏳ Wait: Component builds                              [15-30 min]
+  14:30 │ ⧗ Step 3b: Bundle setup (SHAs + Tekton)               [1-2 hours]
+  16:00 │ ⏳ Wait: Bundle builds                                 [15-30 min]
+        └─────────────────────────────────────────────────────────────────
+
+Day 2-3 (Tue-Wed)                                               [7-33 hours] ⚠️
+──────────────────────────────────────────────────────────────────────────────
+  09:00 │ ⧗ Step 4: Fix EC violations                           [2-8 hours]
+  12:00 │ ⏳ Wait: Rebuilds after EC fixes                       [30-60 min]
+  13:00 │ ⧗⚠️ Step 5: CVE scanning & fixes (ITERATIVE)          [4-24 hours]
+        │   ├─ Grype scan upstream (7 repos)                    [1 hour]
+        │   ├─ Clair scan downstream (9 images)                 [1 hour]
+        │   ├─ Triage CVEs (team discussion)                    [1-2 hours]
+        │   ├─ Fix CVEs in source                               [2-8 hours]
+        │   ├─ PR review + merge                                [2-4 hours]
+        │   ├─ Wait for rebuilds                                [30-60 min]
+        │   └─ Re-scan to verify                                [1 hour]
+        │
+  Day 3 │ ⧗ Step 6: Cut upstream release                        [30 min]
+  14:00 │ ⏳ Wait: Upstream images publish                       [15-30 min]
+  14:30 │ ⧗ Step 7: Update bundle SHAs                          [30 min]
+  15:00 │ ⏳ Wait: Bundle rebuild                                [15-30 min]
+        └─────────────────────────────────────────────────────────────────
+
+        ✓ GATE: Builds ready, EC passed, CVEs triaged
+
+
+Week 1-2: STAGE RELEASE
+──────────────────────────────────────────────────────────────────────────────
+
+Day 4 (Thursday)                                                   [4-6 hours]
+──────────────────────────────────────────────────────────────────────────────
+  09:00 │ ⧗ Step 8: Create stage release YAML                   [15 min]
+  09:15 │ ⧗ Step 9: Add release notes (Jira triage)             [1-2 hours]
+        │   ├─ Query CVEs (automatic)                           [15 min]
+        │   ├─ Query other issues                               [15 min]
+        │   ├─ User selection & mapping                         [30-60 min]
+        │   └─ Update YAML with releaseNotes                    [15 min]
+        │
+  11:00 │ ⧗ Step 10: Apply stage release                        [15 min]
+  11:15 │ ⏳ Wait: Stage pipeline                                [20-40 min]
+  12:00 │ ⧗ Step 10b: Verify build                              [10 min]
+  12:15 │ ⧗ Step 11: Update FBC catalog                         [30 min]
+  12:45 │ ⏳ Wait: FBC snapshots rebuild (6 catalogs)            [15-30 min]
+  13:15 │ ⧗ Step 12: Create 6 FBC stage YAMLs                   [30 min]
+  13:45 │ ⧗ Step 13: Apply 6 FBC releases                       [15 min]
+  14:00 │ ⏳ Wait: FBC pipelines (6 parallel)                    [20-40 min]
+  14:45 │ ⧗ Step 13b: Verify all 6 builds                       [10 min]
+  15:00 │ ⧗ Step 14: Share with QE (create Jira)                [15 min]
+        └─────────────────────────────────────────────────────────────────
+
+        ⏸️ WAIT FOR QE APPROVAL (typically 3-7 days, up to 2 weeks)
+
+Day 4-11 (Thu-Thu)                                           [QE Testing] ⏸️
+──────────────────────────────────────────────────────────────────────────────
+        │ QE testing in progress...
+        │ (Monitor for issues, respond to questions)
+        │
+  Day X │ ⚠️ IF ISSUES FOUND:
+        │   ├─ Fix code/config
+        │   ├─ Rebuild components
+        │   ├─ Update FBC catalogs
+        │   ├─ Apply new stage release (increment suffix)
+        │   └─ Re-submit to QE
+        │   └─ Add 3-7 days per cycle
+        │
+  Day Y │ ✅ QE APPROVAL RECEIVED
+        └─────────────────────────────────────────────────────────────────
+
+
+Week 2-3: PRODUCTION RELEASE
+──────────────────────────────────────────────────────────────────────────────
+
+Day 11-12 (Thu-Fri)                                              [2-3 hours]
+──────────────────────────────────────────────────────────────────────────────
+  09:00 │ ⧗ Step 15: Create prod release YAML                   [10 min]
+  09:10 │ ⧗ Step 16: Apply prod release                         [10 min]
+  09:20 │ ⏳ Wait: Prod pipeline                                 [20-40 min]
+  10:00 │ ⧗ Step 16b: Verify build                              [10 min]
+  10:10 │ ⧗ Step 17: Create 6 FBC prod YAMLs                    [10 min]
+  10:20 │ ⧗ Step 18: Apply 6 FBC prod releases                  [10 min]
+  10:30 │ ⏳ Wait: FBC prod pipelines (6 parallel)               [20-40 min]
+  11:15 │ ⧗ Step 18b: Verify all 6 builds                       [10 min]
+  11:30 │ ⧗ Step 19: Notify QE of production                    [10 min]
+        │
+  (opt) │ ⧗ Step 20: Update FBC templates (cleanup)             [1 hour]
+        └─────────────────────────────────────────────────────────────────
+
+        🎉 RELEASE COMPLETE: Submariner 0.22.0 in production
+
+
+================================================================================
+SUBMARINER RELEASE TIMELINE - Z-STREAM (0.21.1 → 0.21.2)
+================================================================================
+
+Week 1: BUILD PREPARATION & STAGE
+──────────────────────────────────────────────────────────────────────────────
+
+Day 1-2 (Mon-Tue)                                               [7-33 hours] ⚠️
+──────────────────────────────────────────────────────────────────────────────
+  09:00 │ ⧗ Step 4: Fix EC violations                           [2-8 hours]
+  12:00 │ ⏳ Wait: Rebuilds after EC fixes                       [30-60 min]
+  13:00 │ ⧗⚠️ Step 5: CVE scanning & fixes (ITERATIVE)          [4-24 hours]
+        │   (Same process as Y-stream)
+        │
+  Day 2 │ ⧗ Step 5b: Update version labels (9 Dockerfiles)      [1 hour]
+  10:00 │ ⏳ Wait: Rebuilds with new labels                      [15-30 min]
+  10:30 │ ⧗ Step 6: Cut upstream release                        [30 min]
+  11:00 │ ⏳ Wait: Upstream images publish                       [15-30 min]
+  11:30 │ ⧗ Step 7: Update bundle SHAs                          [30 min]
+  12:00 │ ⏳ Wait: Bundle rebuild                                [15-30 min]
+        └─────────────────────────────────────────────────────────────────
+
+Day 3 (Wednesday)                                                  [4-6 hours]
+──────────────────────────────────────────────────────────────────────────────
+        │ Steps 8-14: Same as Y-stream
+        │ (See Y-stream Day 4 timeline above)
+        └─────────────────────────────────────────────────────────────────
+
+        ⏸️ WAIT FOR QE APPROVAL (typically 3-7 days)
+
+Day 3-8 (Wed-Wed)                                            [QE Testing] ⏸️
+──────────────────────────────────────────────────────────────────────────────
+        │ QE testing in progress...
+  Day X │ ✅ QE APPROVAL RECEIVED
+        └─────────────────────────────────────────────────────────────────
+
+
+Week 2: PRODUCTION RELEASE
+──────────────────────────────────────────────────────────────────────────────
+
+Day 8-9 (Wed-Thu)                                                [2-3 hours]
+──────────────────────────────────────────────────────────────────────────────
+        │ Steps 15-20: Same as Y-stream
+        │ (See Y-stream Day 11-12 timeline above)
+        └─────────────────────────────────────────────────────────────────
+
+        🎉 RELEASE COMPLETE: Submariner 0.21.2 in production
+
+
+================================================================================
+LEGEND
+================================================================================
+
+  ⧗  Manual work (requires human action)
+  ⏳  Automated wait (pipeline/build/sync)
+  ⏸️  External dependency (QE approval)
+  ⚠️  High variability / risk area
+  ✓  Automated step (minimal human intervention)
+  ✅ Gate/milestone achieved
+
+
+================================================================================
+KEY INSIGHTS
+================================================================================
+
+CRITICAL PATH:
+  Setup (Y) → CVE Fixes → QE Approval → Production
+  └─ Longest: QE approval (3-14 days external dependency)
+
+HIGHEST VARIABILITY:
+  Step 5 (CVE scanning): 4-24 hours
+  └─ Simple releases: 4 hours
+  └─ Complex (Go stdlib CVEs): 24+ hours
+
+PARALLELIZATION:
+  • Step 3: Work on 5 repos simultaneously
+  • Step 5: Fix CVEs in multiple repos in parallel
+  • Step 13/18: 6 FBC releases applied sequentially (avoid cluster overload)
+
+AUTOMATION WINS:
+  • Steps 1, 6: Fully automated (saves ~2 hours per release)
+  • Steps 7, 9, 12: Script-assisted (saves ~4 hours per release)
+  • Future: Steps 2, 3 automation could save additional 3-6 hours
+
+RISK MITIGATION:
+  1. Start CVE scanning early (Day 1-2)
+  2. Validate EC compliance before Step 4
+  3. Thorough pre-QE testing before Step 14
+  4. Monitor pipelines during wait times
+
+
+================================================================================
+TIMELINE ASSUMPTIONS
+================================================================================
+
+• Work hours: 9am-5pm (8 hour day)
+• No blockers or major issues
+• CVE fixes: Moderate complexity (middle of 4-24 hour range)
+• QE approval: Standard timeline (3-7 days)
+• Pipeline success rate: >95% (minimal retries)
+• Team availability: Release manager + on-call developers
+
+ACTUAL TIMELINES MAY VARY based on:
+  - CVE severity and complexity
+  - EC policy changes
+  - QE workload and findings
+  - Infrastructure stability
+  - Team availability
+
+
+Last Updated: 2026-04-08


### PR DESCRIPTION
Add three documentation files providing different views of the Submariner release process for team planning and stakeholder communication:

- RELEASE-PROCESS-OVERVIEW.md: Full reference with Mermaid flowchart, detailed time breakdowns, risk analysis, and resource requirements
- RELEASE-SUMMARY.md: Executive one-page summary with timeline tables, effort distribution, common blockers, and success metrics
- RELEASE-TIMELINE.txt: Hour-by-hour schedule for Y-stream and Z-stream releases showing actual work hours and wait times

These documents provide visibility into:
- Total effort: 17-50 hours (Y-stream) or 13-42 hours (Z-stream)
- Calendar time: 1-3 weeks including QE approval
- Critical path: QE approval (3-14 days external dependency)
- Highest risk: CVE fixes (4-24 hours variable)