### PR TITLE
Fix com.github.url in component setup Dockerfile copy

### DIFF
--- a/scripts/konflux-component-setup.sh
+++ b/scripts/konflux-component-setup.sh
@@ -575,6 +575,14 @@ add_konflux_dockerfile() {
     fi
   fi
 
+  # Fix com.github.url to point to correct repo
+  local CURRENT_REPO
+  CURRENT_REPO=$(basename "$(pwd)")
+  if grep -q 'com.github.url=' "$DOCKERFILE"; then
+    sed -i "s|com.github.url=\"https://github.com/submariner-io/[^\"]*\"|com.github.url=\"https://github.com/submariner-io/${CURRENT_REPO}\"|" "$DOCKERFILE"
+    echo "✓ Set com.github.url to submariner-io/${CURRENT_REPO}"
+  fi
+
   # Update version label for Y-stream (initial version)
   if grep -q 'version=' "$DOCKERFILE"; then
     sed -i "s/version=\"[^\"]*\"/version=\"v${VERSION_MAJOR}.${VERSION_MINOR}.0\"/" "$DOCKERFILE" || \


### PR DESCRIPTION
The Dockerfile is copied from the previous release branch, but com.github.url was never updated to match the current repo. This caused subctl's Dockerfile to point to submariner-operator.