### PR TITLE
Sync operator-sdk version in bundle Dockerfile during setup

### DIFF
--- a/scripts/konflux-bundle-setup.sh
+++ b/scripts/konflux-bundle-setup.sh
@@ -331,6 +331,16 @@ add_bundle_infrastructure() {
   grep -q "BASE_BRANCH=${RELEASE_BRANCH}" .tekton/konflux.args || \
     die "BASE_BRANCH not updated in konflux.args"
 
+  # Sync operator-sdk version from bundle.Dockerfile (kept up to date by make bundle)
+  if [ -f bundle.Dockerfile ]; then
+    local SDK_VERSION
+    SDK_VERSION=$(grep -oP 'metrics\.builder=\K[^ ]+' bundle.Dockerfile || true)
+    if [ -n "$SDK_VERSION" ]; then
+      sed -i "s/metrics\.builder=.*/metrics.builder=${SDK_VERSION}/" bundle.Dockerfile.konflux
+      echo "✓ Synced operator-sdk version: ${SDK_VERSION}"
+    fi
+  fi
+
   echo "✓ Version strings updated (${VERSION}, ${VERSION_DASH}, ${ACM_VERSION})"
 
   # Commit changes


### PR DESCRIPTION
bundle.Dockerfile.konflux had a stale operator-sdk metrics.builder label (v1.40.0) while bundle.Dockerfile (updated by make bundle) had v1.41.1. Now syncs the version from bundle.Dockerfile during konflux-bundle-setup.