### PR TITLE
Add /add-fbc-ocp-version skill for new OCP version setup

### DIFF
--- a/.agents/workflows/add-fbc-ocp-version.md
+++ b/.agents/workflows/add-fbc-ocp-version.md
@@ -20,10 +20,15 @@ Add catalog directory and Tekton pipelines for new OCP version.
 
 Add overlay, tenant config, and RPA entries for new OCP version.
 
-**Repo:** <https://gitlab.cee.redhat.com/releng/konflux-release-data>
-**Local:** `~/konflux/konflux-release-data`
+**Automated:**
 
-**Workflow:** `tenants-config/cluster/kflux-prd-rh02/tenants/submariner-tenant/CLAUDE.md` → "Add FBC Support for New OCP Version"
+```bash
+/add-fbc-ocp-version 4.22 0.23
+# Or: make add-fbc-ocp-version OCP_VERSION=4.22 MIN_SUB=0.23
+```
+
+**Manual:** See `~/konflux/konflux-release-data` tenant CLAUDE.md,
+section "Add FBC Support for New OCP Version"
 
 ### 3. Update Release Workflows (this repo)
 

--- a/.claude/SKILLS.md
+++ b/.claude/SKILLS.md
@@ -27,6 +27,26 @@ Configure Konflux for new Submariner version (Y-stream releases)
 make configure-downstream VERSION=0.23
 ```
 
+## /add-fbc-ocp-version
+
+Add FBC support for new OCP version in Konflux release data
+
+```bash
+/add-fbc-ocp-version 4.22 0.23
+make add-fbc-ocp-version OCP_VERSION=4.22 MIN_SUB=0.23
+```
+
+**Requirements:** `konflux-release-data` repo at `~/konflux/konflux-release-data`, clean working tree on main
+
+**What it does:**
+
+1. Creates FBC overlay directory (8 YAML files)
+2. Enables overlay in tenant config (7 auto-generated files)
+3. Adds new application to FBC stage/prod RPAs
+4. Prints Phase 2 instructions for submariner-operator-fbc
+
+**After running:** Push branch, create GitLab MR, then handle bot PR per Phase 2 instructions
+
 ## /add-team-member
 
 Add user to Submariner Konflux team RBAC

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,4 +137,6 @@ Tasks not tied to normal release workflow timing.
 
 ### Add FBC Support for New OCP Version
 
-@.agents/workflows/add-fbc-ocp-version.md
+@/add-fbc-ocp-version
+
+**Alternative:** `make add-fbc-ocp-version OCP_VERSION=4.22 MIN_SUB=0.23` or @.agents/workflows/add-fbc-ocp-version.md (manual workflow)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test test-remote validate-yaml validate-fields validate-data validate-references validate-bundle-images validate-cve-fixes validate-markdown gitlint shellcheck apply watch configure-downstream create-fbc-releases create-component-release rpm-lockfile-update add-release-notes review-release-notes verify-cve-fixes konflux-component-setup konflux-bundle-setup bundle-image-update get-fbc-urls
+.PHONY: help test test-remote validate-yaml validate-fields validate-data validate-references validate-bundle-images validate-cve-fixes validate-markdown gitlint shellcheck apply watch configure-downstream add-fbc-ocp-version create-fbc-releases create-component-release rpm-lockfile-update add-release-notes review-release-notes verify-cve-fixes konflux-component-setup konflux-bundle-setup bundle-image-update get-fbc-urls
 
 .DEFAULT_GOAL := help
 
@@ -14,6 +14,10 @@ help:
 	@echo "                         - Configure Konflux for new Submariner Y-stream version"
 	@echo "                           Creates overlays, tenant config, and RPAs in konflux-release-data repo"
 	@echo "                           Example: make configure-downstream VERSION=0.24"
+	@echo "  make add-fbc-ocp-version OCP_VERSION=... MIN_SUB=..."
+	@echo "                         - Add FBC support for new OCP version in Konflux release data"
+	@echo "                           Creates overlays, tenant config, and RPA entries"
+	@echo "                           Example: make add-fbc-ocp-version OCP_VERSION=4.22 MIN_SUB=0.23"
 	@echo "  make create-fbc-releases VERSION=... [TYPE=stage|prod]"
 	@echo "                         - Create FBC releases for all 6 OCP versions (requires oc login)"
 	@echo "                           Default TYPE is stage if not specified"
@@ -85,6 +89,11 @@ help:
 configure-downstream:
 	@test -n "$(VERSION)" || (echo "ERROR: VERSION parameter required. Usage: make configure-downstream VERSION=0.24" && exit 1)
 	./scripts/configure-downstream.sh $(VERSION)
+
+add-fbc-ocp-version:
+	@test -n "$(OCP_VERSION)" || (echo "ERROR: OCP_VERSION parameter required. Usage: make add-fbc-ocp-version OCP_VERSION=4.22 MIN_SUB=0.23" && exit 1)
+	@test -n "$(MIN_SUB)" || (echo "ERROR: MIN_SUB parameter required. Usage: make add-fbc-ocp-version OCP_VERSION=4.22 MIN_SUB=0.23" && exit 1)
+	./scripts/add-fbc-ocp-version.sh $(OCP_VERSION) $(MIN_SUB)
 
 create-fbc-releases:
 	@test -n "$(VERSION)" || (echo "ERROR: VERSION parameter required. Usage: make create-fbc-releases VERSION=0.22.1 [TYPE=stage|prod]" && exit 1)

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ acli jira auth status
 | `/learn-release`            | Learn 20-step release workflow                 |
 | `/release-ls`               | Check release status                           |
 | `/configure-downstream`     | Create Konflux app for new version             |
+| `/add-fbc-ocp-version`      | Add FBC support for new OCP version            |
 | `/add-team-member`          | Add user to Submariner Konflux RBAC            |
 | `/konflux-ci-fix`           | Fix Konflux CI Enterprise Contract issues      |
 | `/konflux-component-setup`  | Automate Konflux component setup on new branch |

--- a/scripts/add-fbc-ocp-version.sh
+++ b/scripts/add-fbc-ocp-version.sh
@@ -1,0 +1,257 @@
+#!/bin/bash
+# Add FBC support for new OCP version in Konflux release data
+#
+# Usage: add-fbc-ocp-version.sh <ocp-version> <min-submariner-version>
+#
+# Arguments:
+#   ocp-version: OCP version (e.g., 4.22 or 4-22)
+#   min-submariner-version: Minimum Submariner version for this OCP (e.g., 0.23)
+#
+# What it does:
+#   - Auto-detects previous OCP version from existing overlays
+#   - Creates feature branch (subm-fbc-configure-4-22) from main
+#   - Creates 3 commits with 17 total files:
+#     - Commit 1: 8 YAML overlay files (FBC overlay structure)
+#     - Commit 2: 7 auto-generated Kustomize manifests + kustomization.yaml update
+#     - Commit 3: 2 FBC RPA files updated (applications list)
+#   - Verifies all changes before committing
+#   - Outputs push command, MR instructions, and Phase 2 instructions
+#
+# Exit codes:
+#   0: Success (all 3 commits created)
+#   1: Failure (prerequisites, validation, or commit failed)
+
+set -euo pipefail
+
+OCP_VERSION="${1:-}"
+MIN_SUB="${2:-}"
+
+if [ -z "$OCP_VERSION" ] || [ -z "$MIN_SUB" ]; then
+  echo "❌ Error: Two arguments required"
+  echo "   Usage: add-fbc-ocp-version.sh <ocp-version> <min-submariner-version>"
+  echo "   Example: add-fbc-ocp-version.sh 4.22 0.23"
+  exit 1
+fi
+
+# ━━━ PREREQUISITES VALIDATION ━━━
+
+cd ~/konflux/konflux-release-data || {
+  echo "❌ Error: konflux-release-data repository not found at ~/konflux/konflux-release-data"
+  exit 1
+}
+
+test -f "tenants-config/build-single.sh" || {
+  echo "❌ Error: Invalid konflux-release-data repository (missing build-single.sh)"
+  exit 1
+}
+
+git diff-index --quiet HEAD -- 2>/dev/null || {
+  echo "❌ Error: Working tree has uncommitted changes"
+  echo "   Commit or stash changes before running this script"
+  git status --short
+  exit 1
+}
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+if [ "$CURRENT_BRANCH" != "main" ]; then
+  echo "⚠️  On branch $CURRENT_BRANCH - switching to main"
+  git checkout main
+fi
+
+git fetch origin main 2>/dev/null || echo "⚠️  git fetch failed - working with cached remote state"
+if ! git merge-base --is-ancestor origin/main HEAD 2>/dev/null; then
+  echo "⚠️  Local main behind origin/main - fast-forwarding"
+  git merge --ff-only origin/main
+fi
+
+# ━━━ VERSION NORMALIZATION ━━━
+
+# Normalize OCP version: accept 4.22 or 4-22
+OCP_VERSION="${OCP_VERSION//./-}"
+echo "$OCP_VERSION" | grep -qE '^4-[0-9]+$' || {
+  echo "❌ Error: Invalid OCP version format '$OCP_VERSION'"
+  echo "   Expected: 4.XX or 4-XX (e.g., 4.22 or 4-22)"
+  exit 1
+}
+
+NEW="$OCP_VERSION"
+NEW_DOT="${NEW//-/.}"
+
+echo "$MIN_SUB" | grep -qE '^0\.[0-9]+$' || {
+  echo "❌ Error: Invalid min Submariner version format '$MIN_SUB'"
+  echo "   Expected: 0.XX (e.g., 0.23)"
+  exit 1
+}
+
+# ━━━ VERSION AUTO-DETECTION ━━━
+
+FBC_OVERLAY_DIR="tenants-config/cluster/kflux-prd-rh02/tenants/submariner-tenant/overlay/application-submariner-fbc"
+
+if [ -d "${FBC_OVERLAY_DIR}/${NEW}-overlay" ]; then
+  echo "❌ Error: OCP ${NEW_DOT} already configured"
+  echo "   Overlay directory exists: ${FBC_OVERLAY_DIR}/${NEW}-overlay"
+  exit 1
+fi
+
+EXISTING_VERSIONS=$(find "${FBC_OVERLAY_DIR}" -maxdepth 1 -name '4-*-overlay' -printf '%f\n' 2>/dev/null | \
+  sed 's/-overlay$//' | sort -t- -k2 -n)
+
+if [ -z "$EXISTING_VERSIONS" ]; then
+  echo "❌ Error: No previous FBC versions found"
+  echo "   Expected at least one directory matching: ${FBC_OVERLAY_DIR}/4-*-overlay"
+  exit 1
+fi
+
+PREV=$(echo "$EXISTING_VERSIONS" | tail -1)
+PREV_DOT="${PREV//-/.}"
+
+echo "✓ Version detection:"
+echo "  Previous OCP: ${PREV_DOT}"
+echo "  New OCP:      ${NEW_DOT}"
+echo "  Min Submariner: ${MIN_SUB}"
+echo ""
+
+# ━━━ FEATURE BRANCH CREATION ━━━
+
+BRANCH="subm-fbc-configure-${NEW}"
+
+if git show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then
+  echo "❌ Error: Branch $BRANCH already exists on remote"
+  echo "   Delete it first: git push origin --delete $BRANCH"
+  echo "   Then re-run this script"
+  exit 1
+fi
+
+if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  echo "⚠️  Local branch $BRANCH exists - deleting and recreating"
+  git branch -D "$BRANCH" >/dev/null 2>&1
+fi
+
+git checkout -b "$BRANCH" || {
+  echo "❌ Error: Failed to create branch $BRANCH"
+  exit 1
+}
+
+echo "✓ Created feature branch: $BRANCH"
+echo ""
+
+# ━━━ COMMIT 1: CREATE FBC OVERLAY STRUCTURE (8 files) ━━━
+
+cd "$HOME/konflux/konflux-release-data/${FBC_OVERLAY_DIR}"
+
+cp -r "${PREV}-overlay" "${NEW}-overlay"
+cd "${NEW}-overlay"
+
+find . -name "*.yaml" -exec sed -i \
+    -e "s/$PREV/$NEW/g" \
+    -e "s/$PREV_DOT/$NEW_DOT/g" {} +
+
+FILE_COUNT=$(find . -name "*.yaml" | wc -l)
+[ "$FILE_COUNT" -eq 8 ] || { echo "❌ Expected 8 YAML files, found $FILE_COUNT"; exit 1; }
+
+grep -q "nameSuffix: -$NEW" kustomization.yaml || { echo "❌ nameSuffix not updated in kustomization.yaml"; exit 1; }
+
+grep -rq "submariner-fbc-$NEW" . || { echo "❌ Application name not updated to submariner-fbc-$NEW"; exit 1; }
+
+if grep -rq "$PREV" . || grep -rq "$PREV_DOT" .; then
+  echo "❌ Old version references still present:"
+  grep -rn "$PREV\|$PREV_DOT" . | head -3
+  exit 1
+fi
+
+echo "   ✓ All verifications passed"
+
+cd "$(git rev-parse --show-toplevel)"
+git add "${FBC_OVERLAY_DIR}/${NEW}-overlay"
+git commit -s -m "Add Submariner FBC $NEW_DOT overlay structure"
+
+echo "✅ Commit 1: Created FBC overlay structure (8 files)"
+echo "   - Copied ${PREV}-overlay → ${NEW}-overlay"
+echo "   - Updated version strings (${PREV_DOT} → ${NEW_DOT})"
+echo ""
+
+# ━━━ COMMIT 2: ENABLE OVERLAY IN TENANT CONFIG (7 auto-generated + kustomization) ━━━
+
+cd ~/konflux/konflux-release-data/tenants-config/cluster/kflux-prd-rh02/tenants/submariner-tenant
+
+grep -q "overlay/application-submariner-fbc/$NEW-overlay" kustomization.yaml || {
+  sed -i "/overlay\/application-submariner-fbc\/$PREV-overlay/a\\  - overlay/application-submariner-fbc/$NEW-overlay" kustomization.yaml
+}
+
+cd ~/konflux/konflux-release-data/tenants-config
+./build-single.sh submariner-tenant
+
+COUNT=$(ls auto-generated/cluster/kflux-prd-rh02/tenants/submariner-tenant/*fbc*"${NEW}"*.yaml 2>/dev/null | wc -l)
+[ "$COUNT" -eq 7 ] || { echo "❌ Error: Expected 7 auto-generated FBC files, found $COUNT"; exit 1; }
+
+cd "$(git rev-parse --show-toplevel)"
+git add tenants-config/cluster/kflux-prd-rh02/tenants/submariner-tenant/kustomization.yaml
+git add tenants-config/auto-generated/cluster/kflux-prd-rh02/tenants/submariner-tenant/
+git commit -s -m "Enable Submariner FBC $NEW_DOT in tenant config"
+
+echo "✅ Commit 2: Enabled FBC overlay in tenant config"
+echo "   - Added overlay entry to kustomization.yaml"
+echo "   - Generated 7 auto-generated manifests"
+echo ""
+
+# ━━━ COMMIT 3: UPDATE FBC RPAs (2 files) ━━━
+
+cd ~/konflux/konflux-release-data/config/kflux-prd-rh02.0fk9.p1/product/ReleasePlanAdmission/submariner
+
+for RPA in submariner-fbc-stage.yaml submariner-fbc-prod.yaml; do
+  grep -q "submariner-fbc-$NEW" "$RPA" || {
+    sed -i "/submariner-fbc-$PREV$/a\\    - submariner-fbc-$NEW" "$RPA"
+  }
+done
+
+for RPA in submariner-fbc-stage.yaml submariner-fbc-prod.yaml; do
+  grep -q "submariner-fbc-$NEW" "$RPA" || { echo "❌ $RPA missing submariner-fbc-$NEW"; exit 1; }
+done
+echo "   ✓ Both FBC RPAs updated"
+
+cd "$(git rev-parse --show-toplevel)"
+git add config/kflux-prd-rh02.0fk9.p1/product/ReleasePlanAdmission/submariner/submariner-fbc-stage.yaml
+git add config/kflux-prd-rh02.0fk9.p1/product/ReleasePlanAdmission/submariner/submariner-fbc-prod.yaml
+git commit -s -m "Add Submariner FBC $NEW_DOT to RPAs"
+
+echo "✅ Commit 3: Added FBC $NEW_DOT to RPAs (2 files)"
+echo ""
+
+# ━━━ SUMMARY ━━━
+
+echo "━━━ SUMMARY ━━━"
+echo ""
+echo "✅ Phase 1 complete: 3 commits in konflux-release-data"
+echo "   - 8 overlay files created"
+echo "   - 7 auto-generated manifests built"
+echo "   - 2 RPA files updated"
+echo "   - Branch: $BRANCH"
+echo ""
+echo "📋 Review changes:"
+echo "   git log --oneline -3"
+echo "   git diff main...$BRANCH --stat"
+echo ""
+echo "🚀 Next steps (Phase 1):"
+echo "   1. Review the commits above"
+echo "   2. Push: git push origin $BRANCH"
+echo "   3. Create MR in GitLab UI (auto-opens after push)"
+echo "   4. After merge, wait for ArgoCD deploy (~5-10 min)"
+echo ""
+echo "🔜 Phase 2: After MR merges and bot PR appears in submariner-operator-fbc"
+echo ""
+echo "   cd ~/konflux/submariner-operator-fbc"
+echo "   gh pr list --search \"submariner-fbc-${NEW}\""
+echo ""
+echo "   # Check out bot's branch:"
+echo "   git checkout konflux-submariner-fbc-${NEW}"
+echo ""
+echo "   # Update drop-versions.json - add: \"${NEW_DOT}\": \"${MIN_SUB}\""
+echo "   # Build catalogs:"
+echo "   make build-catalogs validate-catalogs"
+echo ""
+echo "   # Fix Tekton build-args and path filters"
+echo "   # See: CLAUDE.md → 'Add Support for New OCP Version'"
+echo ""
+echo "💡 If you need to start over:"
+echo "   git checkout main"
+echo "   git branch -D $BRANCH"

--- a/skills/add-fbc-ocp-version/SKILL.md
+++ b/skills/add-fbc-ocp-version/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: add-fbc-ocp-version
+description: Add FBC support for new OCP version in Konflux release data - creates overlays, tenant config, and RPA entries.
+version: 1.0.0
+argument-hint: "<ocp-version> <min-submariner-version>"
+user-invocable: true
+allowed-tools: Bash, Read, Glob
+---
+
+# Add FBC OCP Version
+
+Adds FBC (File-Based Catalog) support for a new OCP version in Konflux release data.
+
+**Usage:**
+
+```bash
+/add-fbc-ocp-version 4.22 0.23
+/add-fbc-ocp-version 4-22 0.23  # Hyphenated format also accepted
+```
+
+**What it does:**
+
+- Auto-detects previous OCP version from existing overlays
+- Creates feature branch (subm-fbc-configure-4-22) from main
+- Creates 3 commits:
+  - Commit 1: 8 YAML overlay files (FBC overlay structure)
+  - Commit 2: 7 auto-generated Kustomize manifests + kustomization.yaml
+  - Commit 3: 2 FBC RPA files updated (applications list)
+- Verifies all changes before committing
+- Outputs push command, MR instructions, and Phase 2 instructions
+
+**Arguments:** $ARGUMENTS
+
+---
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# Find git repository root
+GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+if [ -z "$GIT_ROOT" ]; then
+  echo "❌ ERROR: Not in a git repository"
+  exit 1
+fi
+
+# Verify orchestrator script exists
+if [ ! -x "$GIT_ROOT/scripts/add-fbc-ocp-version.sh" ]; then
+  echo "❌ ERROR: Required orchestrator script not found"
+  echo "This skill requires: scripts/add-fbc-ocp-version.sh"
+  exit 1
+fi
+
+# Delegate to orchestrator (passes all arguments)
+exec "$GIT_ROOT/scripts/add-fbc-ocp-version.sh" $ARGUMENTS
+```


### PR DESCRIPTION
## Summary

- Adds `scripts/add-fbc-ocp-version.sh` to automate adding FBC support for new OCP versions in konflux-release-data
- Creates 3 verified commits: overlay structure (8 files), tenant config (7 auto-generated), RPA updates (2 files)
- Registers as `/add-fbc-ocp-version` skill and `make add-fbc-ocp-version` target
- Updates CLAUDE.md, SKILLS.md, README.md, and workflow docs

## Test plan

- [x] `make shellcheck` passes
- [x] `make test` passes (yamllint, validate-fields, validate-data, markdownlint, gitlint, shellcheck)
- [x] Real test with `4.22 0.23` produces correct 3-commit branch in konflux-release-data
- [x] 3 independent blind subagent runs all pass 6/6 verification checks