### PR TITLE
Submariner 0.21.3 stage releases

### DIFF
--- a/releases/0.21/stage/submariner-0-21-3-stage-20260531-01.yaml
+++ b/releases/0.21/stage/submariner-0-21-3-stage-20260531-01.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-0-21-3-stage-20260531-01
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-release-plan-stage-0-21
+  snapshot: submariner-0-21-20260531-172514-000
+  data:
+    releaseNotes:
+      type: RHBA  # Change to RHSA if adding CVEs, RHEA for enhancements
+      issues:
+        fixed: []  # Fill with Step 9 workflow
+      cves: []     # Fill with Step 9 workflow (required if type=RHSA)

--- a/releases/0.21/stage/submariner-0-21-3-stage-20260531-01.yaml
+++ b/releases/0.21/stage/submariner-0-21-3-stage-20260531-01.yaml
@@ -11,7 +11,176 @@ spec:
   snapshot: submariner-0-21-20260531-172514-000
   data:
     releaseNotes:
-      type: RHBA  # Change to RHSA if adding CVEs, RHEA for enhancements
+      type: RHSA
       issues:
-        fixed: []  # Fill with Step 9 workflow
-      cves: []     # Fill with Step 9 workflow (required if type=RHSA)
+        fixed:
+          # CVE Issues (37):
+          - id: ACM-27238
+            source: issues.redhat.com
+          - id: ACM-28294
+            source: issues.redhat.com
+          - id: ACM-28295
+            source: issues.redhat.com
+          - id: ACM-28311
+            source: issues.redhat.com
+          - id: ACM-28313
+            source: issues.redhat.com
+          - id: ACM-28314
+            source: issues.redhat.com
+          - id: ACM-28315
+            source: issues.redhat.com
+          - id: ACM-28316
+            source: issues.redhat.com
+          - id: ACM-28329
+            source: issues.redhat.com
+          - id: ACM-28331
+            source: issues.redhat.com
+          - id: ACM-28333
+            source: issues.redhat.com
+          - id: ACM-28335
+            source: issues.redhat.com
+          - id: ACM-28337
+            source: issues.redhat.com
+          - id: ACM-28339
+            source: issues.redhat.com
+          - id: ACM-28342
+            source: issues.redhat.com
+          - id: ACM-29317
+            source: issues.redhat.com
+          - id: ACM-29511
+            source: issues.redhat.com
+          - id: ACM-29613
+            source: issues.redhat.com
+          - id: ACM-29614
+            source: issues.redhat.com
+          - id: ACM-29631
+            source: issues.redhat.com
+          - id: ACM-29632
+            source: issues.redhat.com
+          - id: ACM-29633
+            source: issues.redhat.com
+          - id: ACM-29634
+            source: issues.redhat.com
+          - id: ACM-29776
+            source: issues.redhat.com
+          - id: ACM-30134
+            source: issues.redhat.com
+          - id: ACM-30726
+            source: issues.redhat.com
+          - id: ACM-30727
+            source: issues.redhat.com
+          - id: ACM-30728
+            source: issues.redhat.com
+          - id: ACM-30729
+            source: issues.redhat.com
+          - id: ACM-31136
+            source: issues.redhat.com
+          - id: ACM-31831
+            source: issues.redhat.com
+          - id: ACM-31840
+            source: issues.redhat.com
+          - id: ACM-32575
+            source: issues.redhat.com
+          - id: ACM-32842
+            source: issues.redhat.com
+          - id: ACM-34108
+            source: issues.redhat.com
+          - id: ACM-34586
+            source: issues.redhat.com
+          - id: ACM-34589
+            source: issues.redhat.com
+          # Non-CVE Issues (7):
+          - id: ACM-30970
+            source: issues.redhat.com
+          - id: ACM-34578
+            source: issues.redhat.com
+      cves:
+        # CVE-2024-25621
+        - key: CVE-2024-25621
+          component: submariner-operator-0-21
+        # CVE-2025-61726 (7 issues)
+        - key: CVE-2025-61726
+          component: lighthouse-agent-0-21
+        - key: CVE-2025-61726
+          component: lighthouse-coredns-0-21
+        - key: CVE-2025-61726
+          component: subctl-0-21
+        - key: CVE-2025-61726
+          component: submariner-gateway-0-21
+        - key: CVE-2025-61726
+          component: submariner-globalnet-0-21
+        - key: CVE-2025-61726
+          component: submariner-operator-0-21
+        - key: CVE-2025-61726
+          component: submariner-route-agent-0-21
+        # CVE-2025-61728
+        - key: CVE-2025-61728
+          component: lighthouse-coredns-0-21
+        # CVE-2025-61729 (7 issues)
+        - key: CVE-2025-61729
+          component: lighthouse-agent-0-21
+        - key: CVE-2025-61729
+          component: lighthouse-coredns-0-21
+        - key: CVE-2025-61729
+          component: subctl-0-21
+        - key: CVE-2025-61729
+          component: submariner-gateway-0-21
+        - key: CVE-2025-61729
+          component: submariner-globalnet-0-21
+        - key: CVE-2025-61729
+          component: submariner-operator-0-21
+        - key: CVE-2025-61729
+          component: submariner-route-agent-0-21
+        # CVE-2025-68121
+        - key: CVE-2025-68121
+          component: subctl-0-21
+        # CVE-2025-68151
+        - key: CVE-2025-68151
+          component: lighthouse-coredns-0-21
+        # CVE-2026-21441 (7 issues)
+        - key: CVE-2026-21441
+          component: lighthouse-agent-0-21
+        - key: CVE-2026-21441
+          component: lighthouse-coredns-0-21
+        - key: CVE-2026-21441
+          component: nettest-0-21
+        - key: CVE-2026-21441
+          component: subctl-0-21
+        - key: CVE-2026-21441
+          component: submariner-gateway-0-21
+        - key: CVE-2026-21441
+          component: submariner-globalnet-0-21
+        - key: CVE-2026-21441
+          component: submariner-route-agent-0-21
+        # CVE-2026-25679
+        - key: CVE-2026-25679
+          component: subctl-0-21
+        # CVE-2026-26017 (2 issues)
+        - key: CVE-2026-26017
+          component: lighthouse-agent-0-21
+        - key: CVE-2026-26017
+          component: lighthouse-coredns-0-21
+        # CVE-2026-26018 (2 issues)
+        - key: CVE-2026-26018
+          component: lighthouse-agent-0-21
+        - key: CVE-2026-26018
+          component: lighthouse-coredns-0-21
+        # CVE-2026-32280
+        - key: CVE-2026-32280
+          component: subctl-0-21
+        # CVE-2026-32936 (2 issues)
+        - key: CVE-2026-32936
+          component: lighthouse-agent-0-21
+        - key: CVE-2026-32936
+          component: lighthouse-coredns-0-21
+        # CVE-2026-33186 (2 issues)
+        - key: CVE-2026-33186
+          component: lighthouse-coredns-0-21
+        - key: CVE-2026-33186
+          component: subctl-0-21
+        # CVE-2026-34986
+        - key: CVE-2026-34986
+          component: submariner-operator-0-21
+        # CVE-2026-35579
+        - key: CVE-2026-35579
+          component: lighthouse-coredns-0-21

--- a/releases/fbc/4-16/stage/submariner-fbc-4-16-stage-20260601-01.yaml
+++ b/releases/fbc/4-16/stage/submariner-fbc-4-16-stage-20260601-01.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-16-stage-20260601-01
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-stage-4-16
+  snapshot: submariner-fbc-4-16-20260601-230324-000

--- a/releases/fbc/4-16/stage/submariner-fbc-4-16-stage-20260601-02.yaml
+++ b/releases/fbc/4-16/stage/submariner-fbc-4-16-stage-20260601-02.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-16-stage-20260601-02
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-stage-4-16
+  snapshot: submariner-fbc-4-16-20260601-230324-000

--- a/releases/fbc/4-16/stage/submariner-fbc-4-16-stage-20260601-03.yaml
+++ b/releases/fbc/4-16/stage/submariner-fbc-4-16-stage-20260601-03.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-16-stage-20260601-03
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-stage-4-16
+  snapshot: submariner-fbc-4-16-20260601-230324-000

--- a/releases/fbc/4-17/stage/submariner-fbc-4-17-stage-20260601-01.yaml
+++ b/releases/fbc/4-17/stage/submariner-fbc-4-17-stage-20260601-01.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-17-stage-20260601-01
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-stage-4-17
+  snapshot: submariner-fbc-4-17-20260601-230324-000

--- a/releases/fbc/4-17/stage/submariner-fbc-4-17-stage-20260601-02.yaml
+++ b/releases/fbc/4-17/stage/submariner-fbc-4-17-stage-20260601-02.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-17-stage-20260601-02
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-stage-4-17
+  snapshot: submariner-fbc-4-17-20260601-230324-000

--- a/releases/fbc/4-17/stage/submariner-fbc-4-17-stage-20260601-03.yaml
+++ b/releases/fbc/4-17/stage/submariner-fbc-4-17-stage-20260601-03.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-17-stage-20260601-03
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-stage-4-17
+  snapshot: submariner-fbc-4-17-20260601-230324-000

--- a/releases/fbc/4-18/stage/submariner-fbc-4-18-stage-20260601-01.yaml
+++ b/releases/fbc/4-18/stage/submariner-fbc-4-18-stage-20260601-01.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-18-stage-20260601-01
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-stage-4-18
+  snapshot: submariner-fbc-4-18-20260601-230324-000

--- a/releases/fbc/4-18/stage/submariner-fbc-4-18-stage-20260601-02.yaml
+++ b/releases/fbc/4-18/stage/submariner-fbc-4-18-stage-20260601-02.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-18-stage-20260601-02
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-stage-4-18
+  snapshot: submariner-fbc-4-18-20260601-230324-000

--- a/releases/fbc/4-18/stage/submariner-fbc-4-18-stage-20260601-03.yaml
+++ b/releases/fbc/4-18/stage/submariner-fbc-4-18-stage-20260601-03.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-18-stage-20260601-03
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-stage-4-18
+  snapshot: submariner-fbc-4-18-20260601-230324-000

--- a/releases/fbc/4-19/stage/submariner-fbc-4-19-stage-20260601-01.yaml
+++ b/releases/fbc/4-19/stage/submariner-fbc-4-19-stage-20260601-01.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-19-stage-20260601-01
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-stage-4-19
+  snapshot: submariner-fbc-4-19-20260601-230324-000

--- a/releases/fbc/4-19/stage/submariner-fbc-4-19-stage-20260601-02.yaml
+++ b/releases/fbc/4-19/stage/submariner-fbc-4-19-stage-20260601-02.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-19-stage-20260601-02
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-stage-4-19
+  snapshot: submariner-fbc-4-19-20260601-230324-000

--- a/releases/fbc/4-19/stage/submariner-fbc-4-19-stage-20260601-03.yaml
+++ b/releases/fbc/4-19/stage/submariner-fbc-4-19-stage-20260601-03.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-19-stage-20260601-03
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-stage-4-19
+  snapshot: submariner-fbc-4-19-20260601-230324-000

--- a/releases/fbc/4-20/stage/submariner-fbc-4-20-stage-20260601-01.yaml
+++ b/releases/fbc/4-20/stage/submariner-fbc-4-20-stage-20260601-01.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-20-stage-20260601-01
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-stage-4-20
+  snapshot: submariner-fbc-4-20-20260601-230324-000

--- a/releases/fbc/4-20/stage/submariner-fbc-4-20-stage-20260601-02.yaml
+++ b/releases/fbc/4-20/stage/submariner-fbc-4-20-stage-20260601-02.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-20-stage-20260601-02
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-stage-4-20
+  snapshot: submariner-fbc-4-20-20260601-230324-000

--- a/releases/fbc/4-20/stage/submariner-fbc-4-20-stage-20260601-03.yaml
+++ b/releases/fbc/4-20/stage/submariner-fbc-4-20-stage-20260601-03.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-20-stage-20260601-03
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-stage-4-20
+  snapshot: submariner-fbc-4-20-20260601-230324-000

--- a/scripts/release-notes/auto-apply.sh
+++ b/scripts/release-notes/auto-apply.sh
@@ -29,9 +29,21 @@ if [[ ! -f "$DATA_JSON" ]]; then
   exit 1
 fi
 
+FORCE="${FORCE:-false}"
+
 banner "Auto-Apply ALL Filtered Issues to Stage YAML"
 
 extract_and_validate_metadata "$DATA_JSON"
+
+# Check if YAML already has populated release notes (not just placeholder)
+EXISTING_ISSUES=$(grep -c "id: ACM-" "$STAGE_YAML" 2>/dev/null || echo 0)
+if [[ "$EXISTING_ISSUES" -gt 0 && "$FORCE" != "true" ]]; then
+  echo "⚠️  Stage YAML already has $EXISTING_ISSUES issues in release notes."
+  echo "    Re-running will overwrite existing notes (including review removals)."
+  echo "    To overwrite: FORCE=true $0 $*"
+  echo "    To review existing: git show"
+  exit 1
+fi
 
 # ============================================================================
 # Build releaseNotes Section

--- a/scripts/release-notes/collect.sh
+++ b/scripts/release-notes/collect.sh
@@ -236,7 +236,7 @@ else
   for KEY in $CVE_KEYS; do
     [[ -z "$KEY" || "$KEY" == "null" ]] && continue
 
-    ISSUE_JSON=$(view_jira "$KEY" --fields "labels,resolutiondate,created") || {
+    ISSUE_JSON=$(view_jira "$KEY" --fields "labels,resolutiondate,created,resolution") || {
       echo "⚠️  $KEY: Failed to fetch details, skipping" >&2
       continue
     }
@@ -265,7 +265,8 @@ else
     [[ "$COMPONENT_MAPPED" == "EXCLUDE" || "$COMPONENT_MAPPED" == "UNKNOWN" ]] && continue
 
     RESOLVED=$(jq -r '(.fields.resolutiondate // "")[:10]' <<< "$ISSUE_JSON")
-    CVE_DATA_LINES+=("$(jq -n --arg ik "$KEY" --arg ck "$CVE_KEY" --arg cm "$COMPONENT_MAPPED" --arg rd "$RESOLVED" '{issue_key:$ik,cve_key:$ck,component_mapped:$cm,resolved:$rd}')")
+    RESOLUTION=$(jq -r '.fields.resolution.name // "Unresolved"' <<< "$ISSUE_JSON")
+    CVE_DATA_LINES+=("$(jq -n --arg ik "$KEY" --arg ck "$CVE_KEY" --arg cm "$COMPONENT_MAPPED" --arg rd "$RESOLVED" --arg res "$RESOLUTION" '{issue_key:$ik,cve_key:$ck,component_mapped:$cm,resolved:$rd,resolution:$res}')")
   done
 
   CVE_ISSUES_JSON=$(printf '%s\n' "${CVE_DATA_LINES[@]}" | jq -s '.')

--- a/scripts/release-notes/prepare.sh
+++ b/scripts/release-notes/prepare.sh
@@ -46,8 +46,10 @@ jq '
 
 # Define invalid resolutions to exclude
 # NOTE: "Unresolved" is intentionally NOT excluded - release is what resolves issues,
-# and Jira hygiene is not great at moving issues to testing/QE status
-["Won\u0027t Do", "Won\u0027t Fix", "Duplicate", "Cannot Reproduce"] as $invalid_resolutions |
+# and Jira hygiene is not great at moving issues to testing/QE status.
+# "Not a Bug" means Product Security evaluated the CVE as not applicable - never include.
+# "Obsolete" is ambiguous but exclude from issues; CVE key preserved if other trackers are Done.
+["Won\u0027t Do", "Won\u0027t Fix", "Duplicate", "Cannot Reproduce", "Not a Bug", "Obsolete"] as $invalid_resolutions |
 
 # Filter non-CVE issues
 (
@@ -72,6 +74,8 @@ jq '
     select(
       # Exclude existing issues (in prod releases)
       (.issue_key | IN($existing[]) | not) and
+      # Exclude invalid resolutions (Not a Bug = CVE not applicable, Obsolete = stale)
+      ((.resolution // "Unresolved") | IN($invalid_resolutions[]) | not) and
       # For Z-streams: exclude issues resolved before last published release
       (if ($meta.last_published_date != "" and .resolved != "")
        then (.resolved >= $meta.last_published_date)
@@ -134,10 +138,53 @@ jq '
 echo "✓ Data prepared: $OUTPUT_JSON"
 
 # ============================================================================
+# Display Excluded Issues
+# ============================================================================
+
+# Show CVE issues that were filtered out (with reason)
+EXCLUDED_CVES=$(jq -r '
+  .existing_issues as $existing |
+  ["Won\u0027t Do", "Won\u0027t Fix", "Duplicate", "Cannot Reproduce", "Not a Bug", "Obsolete"] as $invalid |
+  .metadata as $meta |
+  [.cve_issues[] | select(
+    (.issue_key | IN($existing[])) or
+    ((.resolution // "Unresolved") | IN($invalid[])) or
+    (if ($meta.last_published_date != "" and .resolved != "")
+     then (.resolved < $meta.last_published_date) else false end)
+  ) | "\(.issue_key) (\(.resolution // "Unresolved")): \(.cve_key)"] | .[]
+' "$INPUT_JSON" 2>/dev/null)
+
+if [[ -n "$EXCLUDED_CVES" ]]; then
+  echo ""
+  echo "Excluded CVE issues:"
+  echo "$EXCLUDED_CVES" | while read -r line; do echo "  ✗ $line"; done
+fi
+
+# Show non-CVE issues that were filtered out
+EXCLUDED_NON_CVE=$(jq -r '
+  .existing_issues as $existing |
+  ["Won\u0027t Do", "Won\u0027t Fix", "Duplicate", "Cannot Reproduce", "Not a Bug", "Obsolete"] as $invalid |
+  .metadata as $meta |
+  [.non_cve_issues[] | select(
+    (.issue_key | IN($existing[])) or
+    (.resolution | IN($invalid[])) or
+    (if ($meta.last_published_date != "" and .resolved != "")
+     then (.resolved < $meta.last_published_date) else false end)
+  ) | "\(.issue_key) (\(.resolution))"] | .[]
+' "$INPUT_JSON" 2>/dev/null)
+
+if [[ -n "$EXCLUDED_NON_CVE" ]]; then
+  echo ""
+  echo "Excluded non-CVE issues:"
+  echo "$EXCLUDED_NON_CVE" | while read -r line; do echo "  ✗ $line"; done
+fi
+
+# ============================================================================
 # Display Summary
 # ============================================================================
 
 jq -r '
+"",
 "Summary:",
 "  CVE topics: \(.cve_topics | length)",
 "  Non-CVE issues: \(.statistics.non_cve_total)",


### PR DESCRIPTION
## Component stage release
- Snapshot: `submariner-0-21-20260531-172514-000` (push, EC passed, 9 components)
- Release notes: RHSA with 37 CVE issues (15 unique CVEs) + 2 non-CVE issues
- All CVEs verified fixed via Clair scan

## FBC stage releases
- 5 OCP versions: 4-16 through 4-20
- 4-21/4-22 excluded (0.21 below minimum Submariner version for those catalogs)
- Snapshots from `submariner-fbc-4-XX-20260601-230324-000` (all TestPassed)

## Script fixes (cherry-picked)
- Filter CVE issues by resolution ("Not a Bug", "Obsolete" excluded)
- Log excluded issues during filtering
- Prevent auto-apply from overwriting reviewed release notes

## Apply commands
```bash
# Component stage release
make apply FILE=releases/0.21/stage/submariner-0-21-3-stage-20260531-01.yaml
make watch NAME=submariner-0-21-3-stage-20260531-01

# FBC stage releases
for V in 16 17 18 19 20; do
  make apply FILE=releases/fbc/4-$V/stage/submariner-fbc-4-$V-stage-20260601-01.yaml
done
```