### PR TITLE
Fix release notes CVE filtering and add safety guards

### DIFF
--- a/scripts/release-notes/auto-apply.sh
+++ b/scripts/release-notes/auto-apply.sh
@@ -29,9 +29,21 @@ if [[ ! -f "$DATA_JSON" ]]; then
   exit 1
 fi
 
+FORCE="${FORCE:-false}"
+
 banner "Auto-Apply ALL Filtered Issues to Stage YAML"
 
 extract_and_validate_metadata "$DATA_JSON"
+
+# Check if YAML already has populated release notes (not just placeholder)
+EXISTING_ISSUES=$(grep -c "id: ACM-" "$STAGE_YAML" 2>/dev/null || echo 0)
+if [[ "$EXISTING_ISSUES" -gt 0 && "$FORCE" != "true" ]]; then
+  echo "⚠️  Stage YAML already has $EXISTING_ISSUES issues in release notes."
+  echo "    Re-running will overwrite existing notes (including review removals)."
+  echo "    To overwrite: FORCE=true $0 $*"
+  echo "    To review existing: git show"
+  exit 1
+fi
 
 # ============================================================================
 # Build releaseNotes Section

--- a/scripts/release-notes/collect.sh
+++ b/scripts/release-notes/collect.sh
@@ -236,7 +236,7 @@ else
   for KEY in $CVE_KEYS; do
     [[ -z "$KEY" || "$KEY" == "null" ]] && continue
 
-    ISSUE_JSON=$(view_jira "$KEY" --fields "labels,resolutiondate,created") || {
+    ISSUE_JSON=$(view_jira "$KEY" --fields "labels,resolutiondate,created,resolution") || {
       echo "⚠️  $KEY: Failed to fetch details, skipping" >&2
       continue
     }
@@ -265,7 +265,8 @@ else
     [[ "$COMPONENT_MAPPED" == "EXCLUDE" || "$COMPONENT_MAPPED" == "UNKNOWN" ]] && continue
 
     RESOLVED=$(jq -r '(.fields.resolutiondate // "")[:10]' <<< "$ISSUE_JSON")
-    CVE_DATA_LINES+=("$(jq -n --arg ik "$KEY" --arg ck "$CVE_KEY" --arg cm "$COMPONENT_MAPPED" --arg rd "$RESOLVED" '{issue_key:$ik,cve_key:$ck,component_mapped:$cm,resolved:$rd}')")
+    RESOLUTION=$(jq -r '.fields.resolution.name // "Unresolved"' <<< "$ISSUE_JSON")
+    CVE_DATA_LINES+=("$(jq -n --arg ik "$KEY" --arg ck "$CVE_KEY" --arg cm "$COMPONENT_MAPPED" --arg rd "$RESOLVED" --arg res "$RESOLUTION" '{issue_key:$ik,cve_key:$ck,component_mapped:$cm,resolved:$rd,resolution:$res}')")
   done
 
   CVE_ISSUES_JSON=$(printf '%s\n' "${CVE_DATA_LINES[@]}" | jq -s '.')

--- a/scripts/release-notes/prepare.sh
+++ b/scripts/release-notes/prepare.sh
@@ -46,8 +46,10 @@ jq '
 
 # Define invalid resolutions to exclude
 # NOTE: "Unresolved" is intentionally NOT excluded - release is what resolves issues,
-# and Jira hygiene is not great at moving issues to testing/QE status
-["Won\u0027t Do", "Won\u0027t Fix", "Duplicate", "Cannot Reproduce"] as $invalid_resolutions |
+# and Jira hygiene is not great at moving issues to testing/QE status.
+# "Not a Bug" means Product Security evaluated the CVE as not applicable - never include.
+# "Obsolete" is ambiguous but exclude from issues; CVE key preserved if other trackers are Done.
+["Won\u0027t Do", "Won\u0027t Fix", "Duplicate", "Cannot Reproduce", "Not a Bug", "Obsolete"] as $invalid_resolutions |
 
 # Filter non-CVE issues
 (
@@ -72,6 +74,8 @@ jq '
     select(
       # Exclude existing issues (in prod releases)
       (.issue_key | IN($existing[]) | not) and
+      # Exclude invalid resolutions (Not a Bug = CVE not applicable, Obsolete = stale)
+      ((.resolution // "Unresolved") | IN($invalid_resolutions[]) | not) and
       # For Z-streams: exclude issues resolved before last published release
       (if ($meta.last_published_date != "" and .resolved != "")
        then (.resolved >= $meta.last_published_date)
@@ -134,10 +138,53 @@ jq '
 echo "✓ Data prepared: $OUTPUT_JSON"
 
 # ============================================================================
+# Display Excluded Issues
+# ============================================================================
+
+# Show CVE issues that were filtered out (with reason)
+EXCLUDED_CVES=$(jq -r '
+  .existing_issues as $existing |
+  ["Won\u0027t Do", "Won\u0027t Fix", "Duplicate", "Cannot Reproduce", "Not a Bug", "Obsolete"] as $invalid |
+  .metadata as $meta |
+  [.cve_issues[] | select(
+    (.issue_key | IN($existing[])) or
+    ((.resolution // "Unresolved") | IN($invalid[])) or
+    (if ($meta.last_published_date != "" and .resolved != "")
+     then (.resolved < $meta.last_published_date) else false end)
+  ) | "\(.issue_key) (\(.resolution // "Unresolved")): \(.cve_key)"] | .[]
+' "$INPUT_JSON" 2>/dev/null)
+
+if [[ -n "$EXCLUDED_CVES" ]]; then
+  echo ""
+  echo "Excluded CVE issues:"
+  echo "$EXCLUDED_CVES" | while read -r line; do echo "  ✗ $line"; done
+fi
+
+# Show non-CVE issues that were filtered out
+EXCLUDED_NON_CVE=$(jq -r '
+  .existing_issues as $existing |
+  ["Won\u0027t Do", "Won\u0027t Fix", "Duplicate", "Cannot Reproduce", "Not a Bug", "Obsolete"] as $invalid |
+  .metadata as $meta |
+  [.non_cve_issues[] | select(
+    (.issue_key | IN($existing[])) or
+    (.resolution | IN($invalid[])) or
+    (if ($meta.last_published_date != "" and .resolved != "")
+     then (.resolved < $meta.last_published_date) else false end)
+  ) | "\(.issue_key) (\(.resolution))"] | .[]
+' "$INPUT_JSON" 2>/dev/null)
+
+if [[ -n "$EXCLUDED_NON_CVE" ]]; then
+  echo ""
+  echo "Excluded non-CVE issues:"
+  echo "$EXCLUDED_NON_CVE" | while read -r line; do echo "  ✗ $line"; done
+fi
+
+# ============================================================================
 # Display Summary
 # ============================================================================
 
 jq -r '
+"",
 "Summary:",
 "  CVE topics: \(.cve_topics | length)",
 "  Non-CVE issues: \(.statistics.non_cve_total)",


### PR DESCRIPTION
Three issues fixed in the release notes skill:

1. Filter CVE issues by resolution status
   - Collect resolution field for CVE issues (was missing)
   - Add "Not a Bug" and "Obsolete" to invalid resolutions
   - Apply resolution filter to CVE issues (was only on non-CVE)
   - "Not a Bug" = Product Security says CVE not applicable
   - "Obsolete" = tracker stale; CVE key preserved if sibling tracker has valid resolution

2. Log excluded issues during prepare phase
   - Show which issues were filtered and why (resolution, date, already published) for transparency and debugging

3. Prevent auto-apply from overwriting existing release notes
   - Check if YAML already has populated notes before overwriting
   - Prevents accidental loss of review-phase removals
   - Use FORCE=true to override when intentional