### PR TITLE
Update OCP version loops and references for 4.22

### DIFF
--- a/.agents/workflows/add-fbc-ocp-version.md
+++ b/.agents/workflows/add-fbc-ocp-version.md
@@ -37,9 +37,9 @@ Update OCP version ranges in bash loops. Replace `4-XX` with new version in:
 - `update-fbc-stage.md` - OCP version ranges in Done When
 
 ```bash
-# Example: Adding 4-21 to existing 4-16 through 4-20 range
-# Change: for VERSION in 16 17 18 19 20
-# To:     for VERSION in 16 17 18 19 20 21
+# Example: Adding 4-22 to existing 4-16 through 4-21 range
+# Change: for VERSION in 16 17 18 19 20 21
+# To:     for VERSION in 16 17 18 19 20 21 22
 ```
 
 ## Done When

--- a/.agents/workflows/apply-fbc-releases.md
+++ b/.agents/workflows/apply-fbc-releases.md
@@ -4,7 +4,7 @@
 
 ## Process
 
-Apply all FBC YAMLs to cluster (one per OCP version: 4-16 through 4-21).
+Apply all FBC YAMLs to cluster (one per OCP version: 4-16 through 4-22).
 
 **Repo:** `~/konflux/submariner-release-management`
 

--- a/.agents/workflows/check-fbc-releases.md
+++ b/.agents/workflows/check-fbc-releases.md
@@ -4,13 +4,13 @@
 
 ## Process
 
-Monitor FBC release pipeline executions for all OCP versions (4-16 through 4-21) and verify successful completion.
+Monitor FBC release pipeline executions for all OCP versions (4-16 through 4-22) and verify successful completion.
 
 ## Check Build Status
 
 ```bash
 # Check all FBC stage releases (replace 'stage' with 'prod' for Step 18)
-for VERSION in 16 17 18 19 20 21; do
+for VERSION in 16 17 18 19 20 21 22; do
   RELEASE=$(oc get release -n submariner-tenant --no-headers | grep "submariner-fbc-4-$VERSION-stage" | tail -1 | awk '{print $1}')
   [ -z "$RELEASE" ] && { echo "4-$VERSION: Not applied"; continue; }
 
@@ -130,7 +130,7 @@ After apply, agent returns to **Check Build Status** section to verify retry suc
 
 ## Done When
 
-- All 6 FBC release pipelines completed successfully (4-16 through 4-21)
+- All 7 FBC release pipelines completed successfully (4-16 through 4-22)
 - Index images published to target registries
 - Catalogs updated in indices
 - Ready for next step

--- a/.agents/workflows/create-fbc-prod-release.md
+++ b/.agents/workflows/create-fbc-prod-release.md
@@ -14,7 +14,7 @@ stage and prod (bundle is mirrored). Catalog update to registry.redhat.io URL ha
 
 ## Creating Prod YAMLs
 
-Agent creates prod YAML for each OCP version (4-16 through 4-21):
+Agent creates prod YAML for each OCP version (4-16 through 4-22):
 
 ```bash
 # Copy from stage
@@ -41,6 +41,6 @@ User reviews commit, then pushes.
 FBC prod YAMLs created, committed, and pushed. Ready for Step 18 to apply to cluster.
 
 ```bash
-# Verify files pushed to remote (expect: 4-16 through 4-21)
+# Verify files pushed to remote (expect: 4-16 through 4-22)
 git ls-tree -r --name-only origin/main releases/fbc/*/prod/*.yaml
 ```

--- a/.agents/workflows/create-fbc-stage-release.md
+++ b/.agents/workflows/create-fbc-stage-release.md
@@ -33,19 +33,19 @@ Find recent passing FBC snapshots (built automatically after Step 11):
 # Verify FBC snapshots (built after catalog update) are ready for release
 echo "=== FBC Snapshot Verification ==="
 
-# First verify all 6 GitHub catalogs have the same bundle SHA (catalog consistency)
+# First verify all 7 GitHub catalogs have the same bundle SHA (catalog consistency)
 echo "Verifying GitHub catalog consistency..."
-BUNDLE_SHAS=$(for VERSION in 16 17 18 19 20 21; do
+BUNDLE_SHAS=$(for VERSION in 16 17 18 19 20 21 22; do
   curl -sf "https://raw.githubusercontent.com/stolostron/submariner-operator-fbc/main/catalog-4-$VERSION/bundles/bundle-v0.X.Y.yaml" | grep "^image:" | head -1 | grep -oP 'sha256:\K[a-f0-9]+'
 done | sort -u)
 SHA_COUNT=$(echo "$BUNDLE_SHAS" | grep -c . || echo 0)
-[ "$SHA_COUNT" != "1" ] && { echo "✗ ERROR: FBC catalogs have $SHA_COUNT unique bundle SHAs (expected 1 across all 6 OCP versions)"; exit 1; }
+[ "$SHA_COUNT" != "1" ] && { echo "✗ ERROR: FBC catalogs have $SHA_COUNT unique bundle SHAs (expected 1 across all 7 OCP versions)"; exit 1; }
 EXPECTED_BUNDLE_SHA="$BUNDLE_SHAS"
-echo "✓ Bundle SHA consistent across all 6 GitHub catalogs: ${EXPECTED_BUNDLE_SHA:0:12}"
+echo "✓ Bundle SHA consistent across all 7 GitHub catalogs: ${EXPECTED_BUNDLE_SHA:0:12}"
 
-# Verify snapshot for each OCP version (4-16 through 4-21)
+# Verify snapshot for each OCP version (4-16 through 4-22)
 FAILED=0
-for VERSION in 16 17 18 19 20 21; do
+for VERSION in 16 17 18 19 20 21 22; do
   SNAPSHOT=$(oc get snapshots -n submariner-tenant --sort-by=.metadata.creationTimestamp | grep "^submariner-fbc-4-$VERSION" | tail -1 | awk '{print $1}')
   [ -z "$SNAPSHOT" ] && { echo "4-$VERSION: ✗ No snapshot found"; ((FAILED++)); continue; }
 
@@ -77,10 +77,10 @@ for VERSION in 16 17 18 19 20 21; do
 done
 
 [ $FAILED -gt 0 ] && { echo "✗ $FAILED snapshot(s) failed verification"; exit 1; }
-echo "✓ All 6 FBC snapshots ready for release"
+echo "✓ All 7 FBC snapshots ready for release"
 ```
 
-Agent creates YAML for each OCP version (4-16 through 4-21) with passing snapshot:
+Agent creates YAML for each OCP version (4-16 through 4-22) with passing snapshot:
 
 ```yaml
 ---
@@ -111,7 +111,7 @@ cluster). Ensures complete chain: operator repo → registry bundle → GitHub c
 OP_CSV=$(curl -sf https://raw.githubusercontent.com/submariner-io/submariner-operator/release-0.X/bundle/manifests/submariner.clusterserviceversion.yaml)
 [ -z "$OP_CSV" ] && { echo "✗ ERROR: Failed to fetch operator CSV from GitHub"; exit 1; }
 
-# Fetch FBC bundle (using 4-21 as representative - Section 1 verified all 6 catalogs identical)
+# Fetch FBC bundle (using 4-21 as representative - Section 1 verified all 7 catalogs identical)
 FBC_BUNDLE=$(curl -sf https://raw.githubusercontent.com/stolostron/submariner-operator-fbc/main/catalog-4-21/bundles/bundle-v0.X.Y.yaml)
 [ -z "$FBC_BUNDLE" ] && { echo "✗ ERROR: Failed to fetch FBC bundle from GitHub"; exit 1; }
 
@@ -134,14 +134,14 @@ REG_CSV=$(cat "$TMPDIR/submariner.clusterserviceversion.yaml")
 
 # 2. Get FBC snapshots (extract from YAMLs created in Section 1 - verify what we're releasing!)
 SNAPSHOTS=()
-for VERSION in 16 17 18 19 20 21; do
+for VERSION in 16 17 18 19 20 21 22; do
   YAML_FILE=$(ls releases/fbc/4-$VERSION/stage/*.yaml 2>/dev/null | tail -1)
   [ -z "$YAML_FILE" ] && { echo "✗ ERROR: No stage YAML found for 4-$VERSION"; exit 1; }
   SNAPSHOT=$(awk '/^  snapshot:/ {print $2}' "$YAML_FILE")
   [ -z "$SNAPSHOT" ] && { echo "✗ ERROR: No snapshot in YAML $YAML_FILE"; exit 1; }
   SNAPSHOTS+=("$SNAPSHOT")
 done
-[ ${#SNAPSHOTS[@]} != 6 ] && { echo "✗ ERROR: Expected 6 FBC snapshots, found ${#SNAPSHOTS[@]}"; exit 1; }
+[ ${#SNAPSHOTS[@]} != 7 ] && { echo "✗ ERROR: Expected 7 FBC snapshots, found ${#SNAPSHOTS[@]}"; exit 1; }
 
 # 3. Pre-fetch bundle YAMLs from all snapshots (avoid re-fetching same YAML 7 times per snapshot)
 declare -A SNAPSHOT_BUNDLES
@@ -151,8 +151,8 @@ for SNAPSHOT in "${SNAPSHOTS[@]}"; do
   [ -z "${SNAPSHOT_BUNDLES[$SNAPSHOT]}" ] && { echo "✗ ERROR: Failed to extract bundle from snapshot $SNAPSHOT"; exit 1; }
 done
 
-# 4. Verify component SHAs (7 components × 4 sources + all 6 snapshots)
-echo "=== Verifying component SHAs across 4 sources (+ all 6 snapshots) ==="
+# 4. Verify component SHAs (7 components × 4 sources + all 7 snapshots)
+echo "=== Verifying component SHAs across 4 sources (+ all 7 snapshots) ==="
 MISMATCH=0
 for COMP in submariner-operator submariner-gateway submariner-globalnet submariner-route-agent lighthouse-agent lighthouse-coredns nettest; do
   case $COMP in submariner-route-agent) CSV=submariner-routeagent;; lighthouse-*|nettest) CSV=submariner-$COMP;; *) CSV=$COMP;; esac
@@ -167,7 +167,7 @@ for COMP in submariner-operator submariner-gateway submariner-globalnet submarin
     ((MISMATCH++)); continue
   }
 
-  # Verify all 6 FBC snapshots have same SHA as operator repo (using pre-fetched bundles)
+  # Verify all 7 FBC snapshots have same SHA as operator repo (using pre-fetched bundles)
   SNAP_MISMATCH=0
   for SNAPSHOT in "${SNAPSHOTS[@]}"; do
     SNAP_SHA=$(echo "${SNAPSHOT_BUNDLES[$SNAPSHOT]}" | awk '/relatedImages:/,/schema:/' | grep -B1 "name: $CSV" | grep -oP 'sha256:\K[a-f0-9]+')
@@ -195,11 +195,11 @@ for COMP in submariner-operator submariner-gateway submariner-globalnet submarin
     continue
   fi
 
-  echo "$COMP: ✓ ${OP_SHA:0:12} (verified across all 4 sources + all 6 snapshots)"
+  echo "$COMP: ✓ ${OP_SHA:0:12} (verified across all 4 sources + all 7 snapshots)"
 done
 
 [ $MISMATCH -gt 0 ] && { echo "✗ $MISMATCH component(s) failed"; exit 1; }
-echo "✓ All 7 components verified across 4 sources + all 6 snapshots"
+echo "✓ All 7 components verified across 4 sources + all 7 snapshots"
 ```
 
 If SHAs don't match, **STOP** - Step 8, Step 11, or snapshot builds incomplete/incorrect.
@@ -218,6 +218,6 @@ User reviews commit, then pushes.
 FBC stage YAMLs created, committed, and pushed. Ready for Step 13 to apply to cluster.
 
 ```bash
-# Verify files pushed to remote (expect: 4-16 through 4-21)
+# Verify files pushed to remote (expect: 4-16 through 4-22)
 git ls-tree -r --name-only origin/main releases/fbc/*/stage/*.yaml
 ```

--- a/.agents/workflows/share-with-qe.md
+++ b/.agents/workflows/share-with-qe.md
@@ -14,7 +14,7 @@ Agent extracts catalog URLs for all OCP versions from stage snapshots:
 
 ```bash
 echo "=== FBC Stage Catalog URLs for QE ==="
-for VERSION in 16 17 18 19 20 21; do
+for VERSION in 16 17 18 19 20 21 22; do
   STAGE_YAML=$(ls releases/fbc/4-$VERSION/stage/*.yaml | tail -1)
   SNAPSHOT=$(awk '/^  snapshot:/ {print $2}' "$STAGE_YAML")
   CATALOG=$(oc get snapshot "$SNAPSHOT" -n submariner-tenant \
@@ -63,7 +63,7 @@ rm -rf $TMPDIR
 Create ticket with:
 
 - **Summary:** "Submariner 0.X.Y FBC Stage Ready for Testing"
-- **Description:** Include all 6 catalog URLs
+- **Description:** Include all 7 catalog URLs
 - **Installation:** Point to FBC installation docs (CatalogSource creation)
 
 **Key concept:** Catalog contains operator bundle with registry.redhat.io URLs. ImageDigestMirrors in
@@ -79,11 +79,11 @@ cluster redirect to quay.io for actual image pulls.
 
 ## Share Prod FBC with QE
 
-**When:** When all 6 FBC prod releases show Succeeded status
+**When:** When all 7 FBC prod releases show Succeeded status
 
 ### Check Release Status
 
-Verify all 6 FBC prod releases completed:
+Verify all 7 FBC prod releases completed:
 
 ```bash
 oc get releases -n submariner-tenant --no-headers | \
@@ -100,7 +100,7 @@ Extract index URLs and format message for QE:
 ```bash
 echo "Submariner 0.X.Y Prod FBC Released"
 echo ""
-for VERSION in 16 17 18 19 20 21; do
+for VERSION in 16 17 18 19 20 21 22; do
   RELEASE=$(oc get releases -n submariner-tenant --no-headers | \
     grep "submariner-fbc-4-$VERSION-prod.*Succeeded" | tail -1 | awk '{print $1}')
 
@@ -118,7 +118,7 @@ Replace `0.X.Y` with actual version. Copy the output and share with QE.
 
 ### Verify Index Images (Optional)
 
-**TODO:** Implement verification that all 6 index images contain the expected Submariner 0.X.Y bundle SHA.
+**TODO:** Implement verification that all 7 index images contain the expected Submariner 0.X.Y bundle SHA.
 
 **What to verify:**
 
@@ -136,6 +136,6 @@ Replace `0.X.Y` with actual version. Copy the output and share with QE.
 
 ### Prod Done When
 
-- All 6 FBC prod releases succeeded
+- All 7 FBC prod releases succeeded
 - QE message shared with index URLs
 - **Submariner 0.X.Y production release COMPLETE**

--- a/.agents/workflows/update-fbc-stage.md
+++ b/.agents/workflows/update-fbc-stage.md
@@ -12,7 +12,7 @@ Update catalog in FBC repo with bundle from completed stage release.
 
 ## Done When
 
-For each OCP version (4-16 through 4-21):
+For each OCP version (4-16 through 4-22):
 
 ```bash
 # 1. Check latest snapshot created after catalog update

--- a/scripts/create-fbc-releases.sh
+++ b/scripts/create-fbc-releases.sh
@@ -220,7 +220,7 @@ verify_release() {
   fi
 
   # Extract snapshot names for each OCP version
-  for VERSION_NUM in 16 17 18 19 20 21; do
+  for VERSION_NUM in 16 17 18 19 20 21 22; do
     local SNAPSHOT
     SNAPSHOT=$(echo "$COMBINED_RESULT" | jq -r ".snapshots[\"4-${VERSION_NUM}\"]")
     SNAPSHOTS["4-${VERSION_NUM}"]="$SNAPSHOT"
@@ -246,7 +246,7 @@ generate_yamls() {
   # Change to git root so generate script can use relative paths
   cd "$GIT_ROOT" || exit 1
 
-  for OCP_VERSION in 16 17 18 19 20 21; do
+  for OCP_VERSION in 16 17 18 19 20 21 22; do
     # Get snapshot name from combined JSON
     local SNAPSHOT="${SNAPSHOTS[4-${OCP_VERSION}]}"
 
@@ -267,7 +267,7 @@ generate_yamls() {
   done
 
   echo ""
-  echo "✓ Created 6 FBC ${RELEASE_TYPE} Release YAMLs"
+  echo "✓ Created 7 FBC ${RELEASE_TYPE} Release YAMLs"
 }
 
 # ============================================================================
@@ -331,7 +331,7 @@ commit_changes() {
   local COMMIT_MSG
   COMMIT_MSG="Add FBC ${RELEASE_TYPE} releases for $VERSION
 
-Generated 6 Release CRs (OCP 4-16 through 4-21) with:
+Generated 7 Release CRs (OCP 4-16 through 4-22) with:
 - Verified GitHub catalog consistency
 - Verified FBC snapshots (push events, tests passed)
 - Verified component SHAs across all sources

--- a/scripts/generate-fbc-release.sh
+++ b/scripts/generate-fbc-release.sh
@@ -29,12 +29,12 @@ SNAPSHOT="$2"
 RELEASE_TYPE="$3"
 RELEASE_DATE="$4"
 
-# Validate OCP version format (4-16 through 4-21)
-if [[ "$OCP_VERSION" =~ ^4-(1[6-9]|2[0-1])$ ]]; then
+# Validate OCP version format (4-16 through 4-22)
+if [[ "$OCP_VERSION" =~ ^4-(1[6-9]|2[0-2])$ ]]; then
   :  # OCP version is valid
 else
   echo "❌ ERROR: Invalid OCP version: $OCP_VERSION" >&2
-  echo "Expected: 4-16 through 4-21" >&2
+  echo "Expected: 4-16 through 4-22" >&2
   exit 1
 fi
 

--- a/scripts/get-fbc-urls.sh
+++ b/scripts/get-fbc-urls.sh
@@ -28,7 +28,7 @@ set -euo pipefail
 
 readonly KONFLUX_UI="https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com"
 readonly NAMESPACE="submariner-tenant"
-readonly ALL_OCP_VERSIONS=(16 17 18 19 20 21)
+readonly ALL_OCP_VERSIONS=(16 17 18 19 20 21 22)
 
 # ━━━ GLOBAL VARIABLES ━━━
 

--- a/scripts/release-status.sh
+++ b/scripts/release-status.sh
@@ -40,8 +40,8 @@ readonly SECONDS_PER_DAY=86400
 readonly FBC_DATE_MATCH_WINDOW_DAYS=3
 readonly FBC_DATE_MATCH_WINDOW_SECS=$((FBC_DATE_MATCH_WINDOW_DAYS * SECONDS_PER_DAY))
 readonly BUNDLE_CLOCK_SKEW_SECS=300  # 5 minutes tolerance for clock skew
-readonly CURRENT_OCP_VERSION_COUNT=6
-readonly OCP_VERSIONS="16 17 18 19 20 21"
+readonly CURRENT_OCP_VERSION_COUNT=7
+readonly OCP_VERSIONS="16 17 18 19 20 21 22"
 
 # Submariner component repos (for branch checks)
 readonly SUBMARINER_REPOS="submariner-operator submariner lighthouse shipyard subctl admiral cloud-prepare"
@@ -299,7 +299,7 @@ find_fbc_yaml_by_date() {
 #   $1 - Current scope (space-separated OCP versions, e.g., "16 17 18 19 20")
 # Returns: space-separated list of missing versions compared to OCP_VERSIONS
 #
-# Example: If OCP_VERSIONS="16 17 18 19 20 21" and scope="16 17 18 19 20", returns "21"
+# Example: If OCP_VERSIONS="16 17 18 19 20 21 22" and scope="16 17 18 19 20 21", returns "22"
 get_missing_ocp_versions() {
   local scope=$1
   comm -13 <(echo "$scope" | tr ' ' '\n' | sort) <(echo "$OCP_VERSIONS" | tr ' ' '\n' | sort) | tr '\n' ' ' | xargs

--- a/scripts/verify-fbc-release.sh
+++ b/scripts/verify-fbc-release.sh
@@ -14,7 +14,7 @@
 # Optimizations:
 #   - Batched OC queries: 1 API call instead of 30
 #   - Single-pass extraction: Extract each snapshot once (not twice)
-#   - Parallel extraction: 6 simultaneous extracts (added in Phase 2)
+#   - Parallel extraction: 7 simultaneous extracts (added in Phase 2)
 
 set -euo pipefail
 
@@ -120,7 +120,7 @@ echo "Step 1: Verifying GitHub catalog consistency..." >&2
 declare -A BUNDLE_SHAS
 FAILED=0
 
-for VERSION in 16 17 18 19 20 21; do
+for VERSION in 16 17 18 19 20 21 22; do
   CATALOG_URL="https://raw.githubusercontent.com/stolostron/submariner-operator-fbc/main/catalog-4-${VERSION}/bundles/bundle-v${FULL_VERSION}.yaml"
 
   # Fetch bundle and extract SHA
@@ -144,13 +144,13 @@ if [ $FAILED -eq 0 ]; then
   if [ "$UNIQUE_SHAS" -ne 1 ]; then
     echo "" >&2
     echo "✗ ERROR: FBC catalog bundle SHA mismatch:" >&2
-    for VERSION in 16 17 18 19 20 21; do
+    for VERSION in 16 17 18 19 20 21 22; do
       echo "  4-${VERSION}: ${BUNDLE_SHAS[4-${VERSION}]}" >&2
     done
     echo "" >&2
     echo "Remediation:" >&2
     echo "1. Check if Step 11 (FBC catalog update) completed correctly" >&2
-    echo "2. Verify all 6 catalogs were updated with same bundle SHA" >&2
+    echo "2. Verify all 7 catalogs were updated with same bundle SHA" >&2
     echo "3. Re-run Step 11 if needed" >&2
     exit 1
   fi
@@ -158,7 +158,7 @@ if [ $FAILED -eq 0 ]; then
   # Get the common SHA
   EXPECTED_BUNDLE_SHA="${BUNDLE_SHAS[4-16]}"
   echo "" >&2
-  echo "✓ Bundle SHA consistent across all 6 GitHub catalogs: ${EXPECTED_BUNDLE_SHA:0:12}..." >&2
+  echo "✓ Bundle SHA consistent across all 7 GitHub catalogs: ${EXPECTED_BUNDLE_SHA:0:12}..." >&2
 else
   echo "" >&2
   echo "✗ ERROR: Failed to fetch $FAILED catalog(s)" >&2
@@ -187,7 +187,7 @@ declare -A TEST_STATUSES
 FAILED=0
 FAILED_DETAILS=""
 
-for VERSION in 16 17 18 19 20 21; do
+for VERSION in 16 17 18 19 20 21 22; do
   # Filter for this version, get latest (all in one jq query)
   SNAPSHOT_DATA=""
   SNAPSHOT_DATA=$(echo "$ALL_SNAPSHOTS" | jq -r \
@@ -224,7 +224,7 @@ if [ $FAILED -gt 0 ]; then
 fi
 
 echo "" >&2
-echo "✓ Found all 6 FBC snapshots" >&2
+echo "✓ Found all 7 FBC snapshots" >&2
 
 # ============================================================================
 # Step 3: Single-Pass Bundle Extraction (OPTIMIZATION: Parallel + extract once)
@@ -234,7 +234,7 @@ echo "" >&2
 echo "Step 3: Extracting bundles from snapshots (parallel, single-pass)..." >&2
 
 # Extract each snapshot's bundle ONCE (not twice like old scripts)
-# Use parallel execution for 6 simultaneous extractions
+# Use parallel execution for 7 simultaneous extractions
 # Bundle YAMLs stay in tmpdir for both bundle SHA AND component SHA verification
 
 # Define extraction function for parallel execution
@@ -278,7 +278,7 @@ export -f extract_single_bundle
 export TMPDIR FULL_VERSION
 
 # Launch parallel extraction jobs
-for VERSION in 16 17 18 19 20 21; do
+for VERSION in 16 17 18 19 20 21 22; do
     run_parallel_job "extract-4-${VERSION}" extract_single_bundle \
         "$VERSION" "${SNAPSHOTS[4-${VERSION}]}" "${CATALOG_IMAGES[4-${VERSION}]}" "$FULL_VERSION"
 done
@@ -304,7 +304,7 @@ declare -A VERIFIED_SNAPSHOTS
 FAILED=0
 FAILED_DETAILS=""
 
-for VERSION in 16 17 18 19 20 21; do
+for VERSION in 16 17 18 19 20 21 22; do
   SNAPSHOT="${SNAPSHOTS[4-${VERSION}]}"
   EVENT_TYPE="${EVENT_TYPES[4-${VERSION}]}"
   TESTS_JSON="${TEST_STATUSES[4-${VERSION}]}"
@@ -361,7 +361,7 @@ if [ $FAILED -gt 0 ]; then
 fi
 
 echo "" >&2
-echo "✓ All 6 FBC snapshots ready for release" >&2
+echo "✓ All 7 FBC snapshots ready for release" >&2
 
 # ============================================================================
 # Step 5: Extract Bundle Metadata (Source Commit)
@@ -433,7 +433,7 @@ fi
 
 echo "  ✓ Fetched operator CSV from commit ${SOURCE_COMMIT:0:7}" >&2
 
-# Fetch FBC bundle for comparison (using 4-21 as representative - all 6 catalogs verified identical)
+# Fetch FBC bundle for comparison (using 4-21 as representative - all 7 catalogs verified identical)
 FBC_BUNDLE=$(curl -sf "https://raw.githubusercontent.com/stolostron/submariner-operator-fbc/main/catalog-4-21/bundles/bundle-v${FULL_VERSION}.yaml")
 if [ -z "$FBC_BUNDLE" ]; then
   echo "❌ ERROR: Failed to fetch FBC bundle from GitHub" >&2
@@ -486,9 +486,9 @@ for COMP in submariner-operator submariner-gateway submariner-globalnet submarin
     continue
   fi
 
-  # Verify all 6 FBC snapshots have same SHA as operator repo (using extracted bundles)
+  # Verify all 7 FBC snapshots have same SHA as operator repo (using extracted bundles)
   SNAP_MISMATCH=0
-  for VERSION in 16 17 18 19 20 21; do
+  for VERSION in 16 17 18 19 20 21 22; do
     SNAPSHOT="${SNAPSHOTS[4-${VERSION}]}"
     BUNDLE_YAML="$TMPDIR/extract-4-${VERSION}/bundle-v${FULL_VERSION}.yaml"
 
@@ -542,7 +542,7 @@ if [ $MISMATCH -gt 0 ]; then
 fi
 
 echo "" >&2
-echo "✓ All 7 components verified (operator commit ${SOURCE_COMMIT:0:7}, FBC GitHub, 6 FBC snapshots)" >&2
+echo "✓ All 7 components verified (operator commit ${SOURCE_COMMIT:0:7}, FBC GitHub, 7 FBC snapshots)" >&2
 
 # ============================================================================
 # Step 8: Output Combined JSON
@@ -565,7 +565,7 @@ NT_STATUS=$(echo "${COMPONENT_RESULTS[nettest]}" | cut -d: -f1)
 NT_SHA=$(echo "${COMPONENT_RESULTS[nettest]}" | cut -d: -f2)
 
 # Output JSON to stdout (single line for easy parsing)
-printf '{"status":"pass","bundle_sha":"%s","source_commit":"%s","snapshots":{"4-16":"%s","4-17":"%s","4-18":"%s","4-19":"%s","4-20":"%s","4-21":"%s"},"components":{"submariner-operator":{"status":"%s","sha":"%s"},"submariner-gateway":{"status":"%s","sha":"%s"},"submariner-globalnet":{"status":"%s","sha":"%s"},"submariner-route-agent":{"status":"%s","sha":"%s"},"lighthouse-agent":{"status":"%s","sha":"%s"},"lighthouse-coredns":{"status":"%s","sha":"%s"},"nettest":{"status":"%s","sha":"%s"}}}\n' \
+printf '{"status":"pass","bundle_sha":"%s","source_commit":"%s","snapshots":{"4-16":"%s","4-17":"%s","4-18":"%s","4-19":"%s","4-20":"%s","4-21":"%s","4-22":"%s"},"components":{"submariner-operator":{"status":"%s","sha":"%s"},"submariner-gateway":{"status":"%s","sha":"%s"},"submariner-globalnet":{"status":"%s","sha":"%s"},"submariner-route-agent":{"status":"%s","sha":"%s"},"lighthouse-agent":{"status":"%s","sha":"%s"},"lighthouse-coredns":{"status":"%s","sha":"%s"},"nettest":{"status":"%s","sha":"%s"}}}\n' \
   "$EXPECTED_BUNDLE_SHA" \
   "$SOURCE_COMMIT" \
   "${VERIFIED_SNAPSHOTS[4-16]}" \
@@ -574,6 +574,7 @@ printf '{"status":"pass","bundle_sha":"%s","source_commit":"%s","snapshots":{"4-
   "${VERIFIED_SNAPSHOTS[4-19]}" \
   "${VERIFIED_SNAPSHOTS[4-20]}" \
   "${VERIFIED_SNAPSHOTS[4-21]}" \
+  "${VERIFIED_SNAPSHOTS[4-22]}" \
   "$OP_STATUS" "$OP_SHA" \
   "$GW_STATUS" "$GW_SHA" \
   "$GL_STATUS" "$GL_SHA" \


### PR DESCRIPTION
Add OCP 4-22 to all version loops, validation regexes, count references, JSON output format, and workflow docs across release management scripts.