### PR TITLE
Accept incoming event type alongside push for releases

### DIFF
--- a/.agents/workflows/create-fbc-stage-release.md
+++ b/.agents/workflows/create-fbc-stage-release.md
@@ -63,9 +63,9 @@ for VERSION in 16 17 18 19 20 21 22; do
     ((FAILED++)); continue
   fi
 
-  # Verify push event (PR snapshots fail EC quay_expiration policy)
+  # Verify event type (push/incoming are main-branch builds; reject PR/retest)
   EVENT_TYPE=$(oc get snapshot $SNAPSHOT -n submariner-tenant -o jsonpath='{.metadata.annotations.pac\.test\.appstudio\.openshift\.io/event-type}')
-  [ "$EVENT_TYPE" != "push" ] && { echo "4-$VERSION: ✗ Event '$EVENT_TYPE' (must be 'push')"; ((FAILED++)); continue; }
+  [ "$EVENT_TYPE" != "push" ] && [ "$EVENT_TYPE" != "incoming" ] && { echo "4-$VERSION: ✗ Event '$EVENT_TYPE' (must be 'push' or 'incoming')"; ((FAILED++)); continue; }
 
   # Verify all tests passed
   TESTS=$(oc get snapshot $SNAPSHOT -n submariner-tenant -o jsonpath='{.metadata.annotations.test\.appstudio\.openshift\.io/status}')

--- a/scripts/verify-component-release.sh
+++ b/scripts/verify-component-release.sh
@@ -70,7 +70,7 @@ fi
 SNAPSHOT_NAME=$(echo "$ALL_SNAPSHOTS" | jq -r "
   .items[]
   | select(.metadata.name | startswith(\"submariner-${VERSION_MAJOR_MINOR_DASH}-\"))
-  | select(.metadata.labels.\"pac.test.appstudio.openshift.io/event-type\" == \"push\")
+  | select(.metadata.labels.\"pac.test.appstudio.openshift.io/event-type\" == \"push\" or .metadata.labels.\"pac.test.appstudio.openshift.io/event-type\" == \"incoming\")
   | {name: .metadata.name, created: .metadata.creationTimestamp}
 " | jq -rs 'sort_by(.created) | reverse | .[0].name' 2>/dev/null)
 
@@ -79,7 +79,7 @@ if [ -z "$SNAPSHOT_NAME" ] || [ "$SNAPSHOT_NAME" = "null" ]; then
   echo "" >&2
   echo "Possible causes:" >&2
   echo "- Step 7 not complete (bundle not built)" >&2
-  echo "- Latest snapshot is from PR (not push event)" >&2
+  echo "- Latest snapshot is from PR (not push/incoming event)" >&2
   echo "- Check: oc get snapshots -n submariner-tenant | grep submariner-${VERSION_MAJOR_MINOR_DASH}" >&2
   exit 1
 fi

--- a/scripts/verify-fbc-release.sh
+++ b/scripts/verify-fbc-release.sh
@@ -188,7 +188,7 @@ FAILED=0
 FAILED_DETAILS=""
 
 for VERSION in 16 17 18 19 20 21 22; do
-  # Filter for this version, get latest (all in one jq query)
+  # Filter for this version, prefer push/incoming events (releasable), fall back to latest
   SNAPSHOT_DATA=""
   SNAPSHOT_DATA=$(echo "$ALL_SNAPSHOTS" | jq -r \
     ".items[] | select(.metadata.name | startswith(\"submariner-fbc-4-${VERSION}\")) |
@@ -198,7 +198,9 @@ for VERSION in 16 17 18 19 20 21 22; do
      tests: .metadata.annotations[\"test.appstudio.openshift.io/status\"],
      image: .spec.components[0].containerImage,
      timestamp: .metadata.creationTimestamp} |
-    @json" | jq -s 'sort_by(.timestamp) | last')
+    @json" | jq -s 'sort_by(.timestamp) |
+    (map(select(.event == "push" or .event == "incoming")) | last) //
+    last')
 
   if [ -z "$SNAPSHOT_DATA" ] || [ "$SNAPSHOT_DATA" = "null" ]; then
     echo "  4-${VERSION}: ✗ No snapshot found" >&2
@@ -310,10 +312,10 @@ for VERSION in 16 17 18 19 20 21 22; do
   TESTS_JSON="${TEST_STATUSES[4-${VERSION}]}"
   SNAPSHOT_BUNDLE_SHA=$(cat "$TMPDIR/extract-4-${VERSION}/bundle-sha.txt")
 
-  # Verify event type
-  if [ "$EVENT_TYPE" != "push" ]; then
-    echo "  4-${VERSION}: ✗ Event type '$EVENT_TYPE' (must be 'push')" >&2
-    FAILED_DETAILS="${FAILED_DETAILS}    4-${VERSION}: Event type '$EVENT_TYPE' (must be 'push', not PR)\n"
+  # Verify event type (push and incoming are both main-branch builds; reject PR/retest)
+  if [ "$EVENT_TYPE" != "push" ] && [ "$EVENT_TYPE" != "incoming" ]; then
+    echo "  4-${VERSION}: ✗ Event type '$EVENT_TYPE' (must be 'push' or 'incoming')" >&2
+    FAILED_DETAILS="${FAILED_DETAILS}    4-${VERSION}: Event type '$EVENT_TYPE' (must be 'push' or 'incoming', not PR)\n"
     ((FAILED++))
     continue
   fi
@@ -345,7 +347,7 @@ for VERSION in 16 17 18 19 20 21 22; do
   fi
 
   # All checks passed
-  echo "  4-${VERSION}: ✓ $SNAPSHOT (push, tests passed, bundle SHA verified)" >&2
+  echo "  4-${VERSION}: ✓ $SNAPSHOT ($EVENT_TYPE, tests passed, bundle SHA verified)" >&2
   VERIFIED_SNAPSHOTS["4-${VERSION}"]="$SNAPSHOT"
 done
 


### PR DESCRIPTION
PipelineAsCode labels some main-branch builds as "incoming" instead of "push" when triggered via its incoming webhook path (e.g., Konflux Web UI reruns, or multi-component repo pushes). These builds are functionally identical to push events: same on-push pipeline, same branch, no quay expiration labels, tests pass.

The push-only check was added to prevent PR snapshots (commit 1faf98a) but incoming events did not exist at that time. The bundle-image-update script was already updated to accept incoming in commit 832bfcb.

Changes:
- verify-fbc-release.sh: Accept incoming, prefer push/incoming in snapshot selection over retest-all-comment
- verify-component-release.sh: Accept incoming in snapshot filter
- create-fbc-stage-release.md: Update workflow doc event type check