### PR TITLE
Fix release notes: require merged PRs, not just open

### DIFF
--- a/scripts/release-notes/collect.sh
+++ b/scripts/release-notes/collect.sh
@@ -326,16 +326,17 @@ else
       continue
     fi
 
-    # Skip untouched issues: status New/Backlog + Unresolved + no issue links + no PRs.
+    # Skip untouched issues: status New/Backlog + Unresolved + no issue links + no merged PRs.
     # Only filter truly untouched — "In Progress" or "Testing" means active work
     # even if the fix isn't linked to this Jira key.
+    # Require MERGED PRs (not just open) — an open PR means work in progress, not shipped.
     RESOLUTION=$(jq -r '.fields.resolution.name // "Unresolved"' <<< "$ISSUE_JSON")
     STATUS=$(jq -r '.fields.status.name' <<< "$ISSUE_JSON")
     LINK_COUNT=$(jq '[.fields.issuelinks[]? | select(.type.name != "Cloners")] | length' <<< "$ISSUE_JSON")
     if [[ "$RESOLUTION" == "Unresolved" && "$LINK_COUNT" -eq 0 ]] && echo "$STATUS" | grep -qiE "^(New|Backlog|To Do)$"; then
-      if ! gh search prs "$KEY" --owner submariner-io --json url --limit 1 2>/dev/null | jq -e 'length > 0' >/dev/null 2>&1 && \
-         ! gh search prs "$KEY" --owner stolostron --json url --limit 1 2>/dev/null | jq -e 'length > 0' >/dev/null 2>&1; then
-        echo "  $KEY: Skipping ($STATUS, unresolved, no links, no PRs)"
+      if ! gh search prs "$KEY" --owner submariner-io --state merged --json url --limit 1 2>/dev/null | jq -e 'length > 0' >/dev/null 2>&1 && \
+         ! gh search prs "$KEY" --owner stolostron --state merged --json url --limit 1 2>/dev/null | jq -e 'length > 0' >/dev/null 2>&1; then
+        echo "  $KEY: Skipping ($STATUS, unresolved, no links, no merged PRs)"
         continue
       fi
     fi

--- a/scripts/release-notes/review-prompt.md
+++ b/scripts/release-notes/review-prompt.md
@@ -118,9 +118,10 @@ Keep if ANY of the following:
 - GitHub links found in Jira comments (often the best evidence)
 - Commits or PRs found in submariner-io repos that address the
   specific problem described in the issue (not just keyword overlap)
-- PRs found in stolostron/rhacm-docs (for Documentation issues) —
-  rhacm-docs is the official repo for Submariner user documentation
-  and PRs there are sufficient evidence even without upstream code
+- **Merged** PRs found in stolostron/rhacm-docs (for Documentation
+  issues) targeting a branch for this release version (e.g.,
+  `2.14_stage` for Submariner 0.21) — open/unmerged PRs or PRs
+  targeting a different version branch are NOT evidence of shipped work
 - You are uncertain AND some relevant evidence exists — err on
   inclusion
 


### PR DESCRIPTION
Two fixes for false positive inclusion of unshipped work:

1. collect.sh: When checking if unresolved issues have PRs, require --state merged (not just any PR exists). An open PR means work in progress, not shipped.

2. review-prompt.md: Require rhacm-docs PRs to be merged AND target the correct version branch. Open PRs or PRs targeting different versions are not evidence of shipped work.

Triggered by ACM-34578 (Backlog, unresolved) being included because an open rhacm-docs PR existed targeting 2.15_stage.