### PR TITLE
Submariner 0.21.3 prod releases

### DIFF
--- a/releases/0.21/prod/submariner-0-21-3-prod-20260608-01.yaml
+++ b/releases/0.21/prod/submariner-0-21-3-prod-20260608-01.yaml
@@ -2,12 +2,12 @@
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: Release
 metadata:
-  name: submariner-0-21-3-stage-20260531-01
+  name: submariner-0-21-3-prod-20260608-01
   namespace: submariner-tenant
   labels:
     release.appstudio.openshift.io/author: 'dfarrell07'
 spec:
-  releasePlan: submariner-release-plan-stage-0-21
+  releasePlan: submariner-release-plan-prod-0-21
   snapshot: submariner-0-21-20260531-172514-000
   data:
     releaseNotes:

--- a/releases/fbc/4-16/prod/submariner-fbc-4-16-prod-20260608-01.yaml
+++ b/releases/fbc/4-16/prod/submariner-fbc-4-16-prod-20260608-01.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-16-prod-20260608-01
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-prod-4-16
+  snapshot: submariner-fbc-4-16-20260601-230324-000

--- a/releases/fbc/4-17/prod/submariner-fbc-4-17-prod-20260608-01.yaml
+++ b/releases/fbc/4-17/prod/submariner-fbc-4-17-prod-20260608-01.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-17-prod-20260608-01
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-prod-4-17
+  snapshot: submariner-fbc-4-17-20260601-230324-000

--- a/releases/fbc/4-18/prod/submariner-fbc-4-18-prod-20260608-01.yaml
+++ b/releases/fbc/4-18/prod/submariner-fbc-4-18-prod-20260608-01.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-18-prod-20260608-01
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-prod-4-18
+  snapshot: submariner-fbc-4-18-20260601-230324-000

--- a/releases/fbc/4-19/prod/submariner-fbc-4-19-prod-20260608-01.yaml
+++ b/releases/fbc/4-19/prod/submariner-fbc-4-19-prod-20260608-01.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-19-prod-20260608-01
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-prod-4-19
+  snapshot: submariner-fbc-4-19-20260601-230324-000

--- a/releases/fbc/4-20/prod/submariner-fbc-4-20-prod-20260608-01.yaml
+++ b/releases/fbc/4-20/prod/submariner-fbc-4-20-prod-20260608-01.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-20-prod-20260608-01
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-prod-4-20
+  snapshot: submariner-fbc-4-20-20260601-230324-000


### PR DESCRIPTION
## Component prod release
- Same snapshot as stage (submariner-0-21-20260531-172514-000)
- Release notes: RHSA, 37 CVE + 1 non-CVE (38 total)
- ACM-34578 removed from stage notes (unresolved, open PR targeting wrong branch)

## FBC prod releases
- 5 OCP versions: 4-16 through 4-20
- Same snapshots as stage (-03 retries)

## Apply commands
```bash
make apply FILE=releases/0.21/prod/submariner-0-21-3-prod-20260608-01.yaml

for V in 16 17 18 19 20; do
  make apply FILE=releases/fbc/4-$V/prod/submariner-fbc-4-$V-prod-20260608-01.yaml
done
```