### PR TITLE
Add FBC 4-22 prod releases for 0.24.0

### DIFF
--- a/releases/fbc/4-22/prod/submariner-fbc-4-22-prod-20260602-01.yaml
+++ b/releases/fbc/4-22/prod/submariner-fbc-4-22-prod-20260602-01.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-22-prod-20260602-01
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-prod-4-22
+  snapshot: submariner-fbc-4-22-20260601-001801-000

--- a/releases/fbc/4-22/prod/submariner-fbc-4-22-prod-20260602-02.yaml
+++ b/releases/fbc/4-22/prod/submariner-fbc-4-22-prod-20260602-02.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-22-prod-20260602-02
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-prod-4-22
+  snapshot: submariner-fbc-4-22-20260601-001801-000

--- a/releases/fbc/4-22/prod/submariner-fbc-4-22-prod-20260603-01.yaml
+++ b/releases/fbc/4-22/prod/submariner-fbc-4-22-prod-20260603-01.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-22-prod-20260603-01
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-prod-4-22
+  snapshot: submariner-fbc-4-22-20260601-001801-000


### PR DESCRIPTION
## Summary

Land the OCP 4.22 FBC prod release YAMLs on main. These were ready on the
`fbc-prod-releases-0.24.0` branch but the previous PR (#75) was closed
without merging.

Includes three release attempts — the first two hit signing infra issues
(sign-index-image timed out waiting for robosignatory), the third (#77)
succeeded.

## Files

- `releases/fbc/4-22/prod/submariner-fbc-4-22-prod-20260602-01.yaml`
- `releases/fbc/4-22/prod/submariner-fbc-4-22-prod-20260602-02.yaml`
- `releases/fbc/4-22/prod/submariner-fbc-4-22-prod-20260603-01.yaml`