### PR TITLE
Update acli auth docs to use token instead of web login

### DIFF
--- a/.agents/workflows/add-release-notes.md
+++ b/.agents/workflows/add-release-notes.md
@@ -13,7 +13,8 @@ then per-issue agent review.
 
 ```bash
 # One-time setup
-acli jira auth login --web
+# Create API token at: https://id.atlassian.com/manage-profile/security/api-tokens
+acli jira auth login --token
 acli jira auth status  # Verify authenticated
 ```
 

--- a/.claude/SKILLS.md
+++ b/.claude/SKILLS.md
@@ -182,7 +182,7 @@ make add-release-notes VERSION=0.22.1 STAGE_YAML=path/to/file.yaml
 
 **Requirements:**
 
-- acli authenticated: `acli jira auth login --web`
+- acli authenticated: `acli jira auth login --token` (create token at <https://id.atlassian.com/manage-profile/security/api-tokens>)
 - Step 8 complete (stage YAML exists)
 
 **What it does:**

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ make get-fbc-urls VERSION=0.24.0 PROD_INDEX=true           # Prod operator index
 make verify-cve-fixes STAGE_YAML=releases/0.22/stage/submariner-0-22-1-stage-20260319-01.yaml
 
 # Setup acli (one-time)
-acli jira auth login --web
+# Create API token at: https://id.atlassian.com/manage-profile/security/api-tokens
+acli jira auth login --token
 acli jira auth status
 ```
 

--- a/scripts/release-notes/collect.sh
+++ b/scripts/release-notes/collect.sh
@@ -73,8 +73,9 @@ echo "Testing acli authentication..."
 if ! acli jira workitem search --jql 'project=ACM' --limit 1 --json </dev/null >/dev/null 2>&1; then
   echo "❌ ERROR: acli authentication failed" >&2
   echo "Setup steps:" >&2
-  echo "  1. acli jira auth login --web" >&2
-  echo "  2. acli jira auth status" >&2
+  echo "  1. Create API token: https://id.atlassian.com/manage-profile/security/api-tokens" >&2
+  echo "  2. acli jira auth login --token" >&2
+  echo "  3. acli jira auth status" >&2
   exit 1
 fi
 echo "✓ Authenticated to redhat.atlassian.net"


### PR DESCRIPTION
Replace `acli jira auth login --web` with `--token` across all docs and scripts. Add link to Atlassian API token management page where users create tokens.