### PR TITLE
Accept retest-all-comment event type and add /retest docs

### DIFF
--- a/.agents/workflows/create-fbc-stage-release.md
+++ b/.agents/workflows/create-fbc-stage-release.md
@@ -63,9 +63,9 @@ for VERSION in 16 17 18 19 20 21 22; do
     ((FAILED++)); continue
   fi
 
-  # Verify event type (push/incoming are main-branch builds; reject PR/retest)
+  # Verify event type (push/incoming/retest-all-comment are main-branch builds; reject PR)
   EVENT_TYPE=$(oc get snapshot $SNAPSHOT -n submariner-tenant -o jsonpath='{.metadata.annotations.pac\.test\.appstudio\.openshift\.io/event-type}')
-  [ "$EVENT_TYPE" != "push" ] && [ "$EVENT_TYPE" != "incoming" ] && { echo "4-$VERSION: ✗ Event '$EVENT_TYPE' (must be 'push' or 'incoming')"; ((FAILED++)); continue; }
+  [ "$EVENT_TYPE" != "push" ] && [ "$EVENT_TYPE" != "incoming" ] && [ "$EVENT_TYPE" != "retest-all-comment" ] && { echo "4-$VERSION: ✗ Event '$EVENT_TYPE' (not a main-branch build)"; ((FAILED++)); continue; }
 
   # Verify all tests passed
   TESTS=$(oc get snapshot $SNAPSHOT -n submariner-tenant -o jsonpath='{.metadata.annotations.test\.appstudio\.openshift\.io/status}')

--- a/.agents/workflows/fix-ec-violations.md
+++ b/.agents/workflows/fix-ec-violations.md
@@ -44,3 +44,17 @@ Ensure all Konflux builds pass Enterprise Contract validation before cutting rel
   oc get snapshot <snapshot-name> -n submariner-tenant -o jsonpath='{.metadata.annotations.test\.appstudio\.openshift\.io/status}' | jq '.[] | {scenario, status}'
   # Should show: "status": "TestPassed" for standard and operator scenarios
   ```
+
+### Retrigger Failed Push Builds
+
+If a push build fails due to an infra flake, retrigger with a `/retest` comment on the HEAD commit:
+
+```bash
+# Component repos
+gh api repos/submariner-io/<repo>/commits/release-0.X --jq '.sha' | \
+  xargs -I{} gh api repos/submariner-io/<repo>/commits/{}/comments -f body="/retest"
+
+# FBC repo
+gh api repos/stolostron/submariner-operator-fbc/commits/main --jq '.sha' | \
+  xargs -I{} gh api repos/stolostron/submariner-operator-fbc/commits/{}/comments -f body="/retest"
+```

--- a/.agents/workflows/update-fbc-stage.md
+++ b/.agents/workflows/update-fbc-stage.md
@@ -25,3 +25,18 @@ oc get snapshot $SNAPSHOT -n submariner-tenant -o jsonpath='{.metadata.annotatio
 ```
 
 Record snapshot names for all OCP versions - needed for Step 12.
+
+### Retrigger Failed Push Builds
+
+If a push build fails due to an infra flake (e.g., `PipelineValidationFailed` with all tasks passing), retrigger
+with a `/retest` comment on the HEAD commit of the target branch:
+
+```bash
+# Find the HEAD commit
+gh api repos/stolostron/submariner-operator-fbc/commits/main --jq '.sha'
+
+# Add /retest comment (retriggers all push pipelines for that commit)
+gh api repos/stolostron/submariner-operator-fbc/commits/<sha>/comments -f body="/retest"
+```
+
+The retested build uses the same push pipeline and produces permanent images (no expiration).

--- a/scripts/bundle-image-update.sh
+++ b/scripts/bundle-image-update.sh
@@ -216,7 +216,7 @@ find_snapshot() {
     # Get snapshot names only (avoids JSON corruption with large result sets)
     local SNAPSHOT_NAMES
     SNAPSHOT_NAMES=$(oc get snapshots -n submariner-tenant \
-      -l 'pac.test.appstudio.openshift.io/event-type in (push,retest-comment,incoming)' \
+      -l 'pac.test.appstudio.openshift.io/event-type in (push,retest-all-comment,incoming)' \
       --sort-by=.metadata.creationTimestamp -o name | \
       grep "^snapshot.appstudio.redhat.com/submariner-${VERSION_DASH}")
 

--- a/scripts/verify-component-release.sh
+++ b/scripts/verify-component-release.sh
@@ -70,7 +70,7 @@ fi
 SNAPSHOT_NAME=$(echo "$ALL_SNAPSHOTS" | jq -r "
   .items[]
   | select(.metadata.name | startswith(\"submariner-${VERSION_MAJOR_MINOR_DASH}-\"))
-  | select(.metadata.labels.\"pac.test.appstudio.openshift.io/event-type\" == \"push\" or .metadata.labels.\"pac.test.appstudio.openshift.io/event-type\" == \"incoming\")
+  | select(.metadata.labels.\"pac.test.appstudio.openshift.io/event-type\" == \"push\" or .metadata.labels.\"pac.test.appstudio.openshift.io/event-type\" == \"incoming\" or .metadata.labels.\"pac.test.appstudio.openshift.io/event-type\" == \"retest-all-comment\")
   | {name: .metadata.name, created: .metadata.creationTimestamp}
 " | jq -rs 'sort_by(.created) | reverse | .[0].name' 2>/dev/null)
 
@@ -79,7 +79,7 @@ if [ -z "$SNAPSHOT_NAME" ] || [ "$SNAPSHOT_NAME" = "null" ]; then
   echo "" >&2
   echo "Possible causes:" >&2
   echo "- Step 7 not complete (bundle not built)" >&2
-  echo "- Latest snapshot is from PR (not push/incoming event)" >&2
+  echo "- Latest snapshot is from PR (not push/incoming/retest event)" >&2
   echo "- Check: oc get snapshots -n submariner-tenant | grep submariner-${VERSION_MAJOR_MINOR_DASH}" >&2
   exit 1
 fi

--- a/scripts/verify-fbc-release.sh
+++ b/scripts/verify-fbc-release.sh
@@ -200,7 +200,7 @@ for VERSION in "${APPLICABLE_VERSIONS[@]}"; do
      image: .spec.components[0].containerImage,
      timestamp: .metadata.creationTimestamp} |
     @json" | jq -s 'sort_by(.timestamp) |
-    (map(select(.event == "push" or .event == "incoming")) | last) //
+    (map(select(.event == "push" or .event == "incoming" or .event == "retest-all-comment")) | last) //
     last')
 
   if [ -z "$SNAPSHOT_DATA" ] || [ "$SNAPSHOT_DATA" = "null" ]; then
@@ -315,10 +315,10 @@ for VERSION in "${APPLICABLE_VERSIONS[@]}"; do
   TESTS_JSON="${TEST_STATUSES[4-${VERSION}]}"
   SNAPSHOT_BUNDLE_SHA=$(cat "$TMPDIR/extract-4-${VERSION}/bundle-sha.txt")
 
-  # Verify event type (push and incoming are both main-branch builds; reject PR/retest)
-  if [ "$EVENT_TYPE" != "push" ] && [ "$EVENT_TYPE" != "incoming" ]; then
-    echo "  4-${VERSION}: ✗ Event type '$EVENT_TYPE' (must be 'push' or 'incoming')" >&2
-    FAILED_DETAILS="${FAILED_DETAILS}    4-${VERSION}: Event type '$EVENT_TYPE' (must be 'push' or 'incoming', not PR)\n"
+  # Verify event type (push, incoming, and retest-all-comment are main-branch builds; reject PR)
+  if [ "$EVENT_TYPE" != "push" ] && [ "$EVENT_TYPE" != "incoming" ] && [ "$EVENT_TYPE" != "retest-all-comment" ]; then
+    echo "  4-${VERSION}: ✗ Event type '$EVENT_TYPE' (must be 'push', 'incoming', or 'retest-all-comment')" >&2
+    FAILED_DETAILS="${FAILED_DETAILS}    4-${VERSION}: Event type '$EVENT_TYPE' (not a main-branch build)\n"
     FAILED=$((FAILED + 1))
     continue
   fi


### PR DESCRIPTION
PaC sets event type to "retest-all-comment" when a build is retriggered via /retest commit comment. These builds use the same push pipeline and produce permanent images (no expiration), so they are safe for releases.

Scripts:
- verify-fbc-release.sh: Accept in preference filter and validation
- verify-component-release.sh: Accept in snapshot selection filter
- bundle-image-update.sh: Fix typo (retest-comment → retest-all-comment)
- create-fbc-stage-release.md: Update inline bash check

Docs:
- update-fbc-stage.md: Add /retest retrigger instructions
- fix-ec-violations.md: Add /retest retrigger instructions