### PR TITLE
Add FBC stage releases for 0.20.3

### DIFF
--- a/releases/fbc/4-16/stage/submariner-fbc-4-16-stage-20260703-01.yaml
+++ b/releases/fbc/4-16/stage/submariner-fbc-4-16-stage-20260703-01.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-16-stage-20260703-01
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-stage-4-16
+  snapshot: submariner-fbc-4-16-20260703-215942-000

--- a/releases/fbc/4-17/stage/submariner-fbc-4-17-stage-20260703-01.yaml
+++ b/releases/fbc/4-17/stage/submariner-fbc-4-17-stage-20260703-01.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-17-stage-20260703-01
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-stage-4-17
+  snapshot: submariner-fbc-4-17-20260703-215942-000

--- a/releases/fbc/4-18/stage/submariner-fbc-4-18-stage-20260703-01.yaml
+++ b/releases/fbc/4-18/stage/submariner-fbc-4-18-stage-20260703-01.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-18-stage-20260703-01
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-stage-4-18
+  snapshot: submariner-fbc-4-18-20260703-215942-000

--- a/releases/fbc/4-19/stage/submariner-fbc-4-19-stage-20260703-01.yaml
+++ b/releases/fbc/4-19/stage/submariner-fbc-4-19-stage-20260703-01.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: Release
+metadata:
+  name: submariner-fbc-4-19-stage-20260703-01
+  namespace: submariner-tenant
+  labels:
+    release.appstudio.openshift.io/author: 'dfarrell07'
+spec:
+  releasePlan: submariner-fbc-release-plan-stage-4-19
+  snapshot: submariner-fbc-4-19-20260703-215942-000


### PR DESCRIPTION
4 FBC stage releases (OCP 4-16 through 4-19).
4-20 through 4-22 excluded (0.20 below minimum Submariner version). Snapshots from retest-all-comment builds after catalog update.